### PR TITLE
Make Connector::cost safe

### DIFF
--- a/vibrato/src/dictionary/connector.rs
+++ b/vibrato/src/dictionary/connector.rs
@@ -33,20 +33,18 @@ impl Connector {
     /// Gets the value of the connection matrix
     #[inline(always)]
     pub fn cost(&self, right_id: u16, left_id: u16) -> i16 {
+        // NOTE: Since this function will be called most frequently, it should be implemented
+        // using `unchecked` for time performance. Experiments showed that using `unchecked`
+        // improved the tokenization time by 5%.
         let index = self.index(right_id, left_id);
         self.data[index]
     }
 
-    /// Gets the value of the connection matrix
-    ///
-    /// # Safety
-    ///
-    /// hoge
-    #[inline(always)]
-    pub unsafe fn cost_unchecked(&self, right_id: u16, left_id: u16) -> i16 {
-        let index = self.index(right_id, left_id);
-        *self.data.get_unchecked(index)
-    }
+    // #[inline(always)]
+    // pub unsafe fn cost_unchecked(&self, right_id: u16, left_id: u16) -> i16 {
+    //     let index = self.index(right_id, left_id);
+    //     *self.data.get_unchecked(index)
+    // }
 
     /// Returns maximum number of left connection ID
     #[inline(always)]

--- a/vibrato/src/tokenizer/lattice.rs
+++ b/vibrato/src/tokenizer/lattice.rs
@@ -123,9 +123,7 @@ impl Lattice {
         let mut min_cost = MAX_COST;
         for (i, left_node) in self.ends[usize::from(start_node)].iter().enumerate() {
             debug_assert!(left_node.is_connected_to_bos());
-            // Safety: hogehoge
-            let conn_cost =
-                unsafe { i32::from(connector.cost_unchecked(left_node.right_id, left_id)) };
+            let conn_cost = i32::from(connector.cost(left_node.right_id, left_id));
             let new_cost = left_node.min_cost + conn_cost;
             // Use <= to produce the same tokenization as MeCab
             if new_cost <= min_cost {


### PR DESCRIPTION
This PR made `Connector::cost` safe.

With this modification, tokenization time was degraded by ~5% (on bccwj-texts).
But, adding pre-verification of connection ids would complicate the implementation, so not using `unchecked` would be reasonable.