### PR TITLE
Omit mut from Tokenizer

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tokenizer = Tokenizer::new(dict)
         .ignore_space(args.ignore_space)?
         .max_grouping_len(args.max_grouping_len.unwrap_or(0));
-    let mut state = tokenizer.new_state();
+    let mut worker = tokenizer.new_worker();
 
     let lines: Vec<_> = std::io::stdin()
         .lock()
@@ -51,9 +51,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         for _ in 0..RUNS {
             t.start();
             for line in &lines {
-                state.reset_sentence(line).unwrap();
-                tokenizer.tokenize(&mut state);
-                n_words += state.num_tokens();
+                worker.reset_sentence(line).unwrap();
+                worker.tokenize();
+                n_words += worker.num_tokens();
             }
             t.stop();
         }

--- a/prepare/src/train.rs
+++ b/prepare/src/train.rs
@@ -28,16 +28,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     let dict = unsafe { Dictionary::read_unchecked(reader)? };
 
     eprintln!("Training connection id mappings...");
-    let mut tokenizer = Tokenizer::new(&dict);
-    let mut counter = tokenizer.new_connid_counter();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
+    state.init_connid_counter();
 
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
-        tokenizer.tokenize(line)?;
-        tokenizer.add_connid_counts(&mut counter);
+        state.reset_sentence(line)?;
+        tokenizer.tokenize(&mut state);
+        state.update_connid_counts();
     }
-    let (lid_probs, rid_probs) = counter.compute_probs();
+    let (lid_probs, rid_probs) = state.compute_connid_probs();
 
     eprintln!("Writting connection id mappings...");
     {

--- a/prepare/src/train.rs
+++ b/prepare/src/train.rs
@@ -29,17 +29,17 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     eprintln!("Training connection id mappings...");
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-    state.init_connid_counter();
+    let mut worker = tokenizer.new_worker();
+    worker.init_connid_counter();
 
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
-        state.reset_sentence(line)?;
-        tokenizer.tokenize(&mut state);
-        state.update_connid_counts();
+        worker.reset_sentence(line)?;
+        worker.tokenize();
+        worker.update_connid_counts();
     }
-    let (lid_probs, rid_probs) = state.compute_connid_probs();
+    let (lid_probs, rid_probs) = worker.compute_connid_probs();
 
     eprintln!("Writting connection id mappings...");
     {

--- a/tokenize/src/main.rs
+++ b/tokenize/src/main.rs
@@ -63,35 +63,35 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tokenizer = Tokenizer::new(dict)
         .ignore_space(args.ignore_space)?
         .max_grouping_len(args.max_grouping_len.unwrap_or(0));
-    let mut state = tokenizer.new_state();
+    let mut worker = tokenizer.new_worker();
 
     eprintln!("Ready to tokenize");
 
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
-        state.reset_sentence(line)?;
-        tokenizer.tokenize(&mut state);
+        worker.reset_sentence(line)?;
+        worker.tokenize();
         match args.output_mode {
             OutputMode::Mecab => {
-                for i in 0..state.num_tokens() {
-                    let t = state.token(i);
+                for i in 0..worker.num_tokens() {
+                    let t = worker.token(i);
                     println!("{}\t{}", t.surface(), t.feature());
                 }
                 println!("EOS");
             }
             OutputMode::Wakati => {
-                for i in 0..state.num_tokens() {
+                for i in 0..worker.num_tokens() {
                     if i != 0 {
                         print!(" ");
                     }
-                    print!("{}", state.token(i).surface());
+                    print!("{}", worker.token(i).surface());
                 }
                 println!();
             }
             OutputMode::Detail => {
-                for i in 0..state.num_tokens() {
-                    let t = state.token(i);
+                for i in 0..worker.num_tokens() {
+                    let t = worker.token(i);
                     println!(
                         "{}\t{}\tlex_type={:?}\tleft_id={}\tright_id={}\tword_cost={}\ttotal_cost={}",
                         t.surface(),

--- a/tokenize/src/main.rs
+++ b/tokenize/src/main.rs
@@ -60,40 +60,38 @@ fn main() -> Result<(), Box<dyn Error>> {
         dict = dict.user_lexicon_from_reader(Some(File::open(userlex_csv_filename)?))?;
     }
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    if args.ignore_space {
-        tokenizer = tokenizer.ignore_space(true).unwrap();
-    }
-    if let Some(max_grouping_len) = args.max_grouping_len {
-        tokenizer = tokenizer.max_grouping_len(max_grouping_len);
-    }
+    let tokenizer = Tokenizer::new(dict)
+        .ignore_space(args.ignore_space)?
+        .max_grouping_len(args.max_grouping_len.unwrap_or(0));
+    let mut state = tokenizer.new_state();
 
     eprintln!("Ready to tokenize");
 
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
-        let tokens = tokenizer.tokenize(line)?;
+        state.reset_sentence(line)?;
+        tokenizer.tokenize(&mut state);
         match args.output_mode {
             OutputMode::Mecab => {
-                for i in 0..tokens.len() {
-                    let t = tokens.get(i);
+                for i in 0..state.num_tokens() {
+                    let t = state.token(i);
                     println!("{}\t{}", t.surface(), t.feature());
                 }
                 println!("EOS");
             }
             OutputMode::Wakati => {
-                for i in 0..tokens.len() {
+                for i in 0..state.num_tokens() {
                     if i != 0 {
                         print!(" ");
                     }
-                    print!("{}", tokens.get(i).surface());
+                    print!("{}", state.token(i).surface());
                 }
                 println!();
             }
             OutputMode::Detail => {
-                for i in 0..tokens.len() {
-                    let t = tokens.get(i);
+                for i in 0..state.num_tokens() {
+                    let t = state.token(i);
                     println!(
                         "{}\t{}\tlex_type={:?}\tleft_id={}\tright_id={}\tword_cost={}\ttotal_cost={}",
                         t.surface(),

--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -31,7 +31,7 @@ impl ConnIdMapper {
     }
 }
 
-/// Trained probabilities of connection ids.
+/// Trained occurrence probabilities of connection ids.
 pub type ConnIdProbs = Vec<(usize, f64)>;
 
 /// Counter to train mappings of connection ids.
@@ -41,7 +41,7 @@ pub struct ConnIdCounter {
 
 impl ConnIdCounter {
     /// Creates a new counter for the matrix of `num_left \times num_right`.
-    pub(crate) fn new(num_left: usize, num_right: usize) -> Self {
+    pub fn new(num_left: usize, num_right: usize) -> Self {
         Self {
             // The initial value 1 is for avoiding zero frequency.
             lid_to_rid_count: vec![vec![1; num_right]; num_left],
@@ -49,7 +49,7 @@ impl ConnIdCounter {
     }
 
     #[inline(always)]
-    pub(crate) fn add(&mut self, left_id: u16, right_id: u16, num: usize) {
+    pub fn add(&mut self, left_id: u16, right_id: u16, num: usize) {
         self.lid_to_rid_count[usize::from(left_id)][usize::from(right_id)] += num;
     }
 
@@ -94,6 +94,7 @@ impl ConnIdCounter {
         }
 
         // Pop Id = 0
+        assert_eq!(crate::common::BOS_EOS_CONNECTION_ID, 0);
         lid_probs.drain(..1);
         rid_probs.drain(..1);
 

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -24,7 +24,7 @@
 //! let tokenizer = vibrato::Tokenizer::new(dict);
 //! let mut state = tokenizer.new_state();
 //!
-//! state.reset_sentence("京都東京都");
+//! state.reset_sentence("京都東京都").unwrap();
 //! tokenizer.tokenize(&mut state);
 //! assert_eq!(state.num_tokens(), 2);
 //!

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -22,19 +22,19 @@
 )]
 //!
 //! let tokenizer = vibrato::Tokenizer::new(dict);
-//! let mut state = tokenizer.new_state();
+//! let mut worker = tokenizer.new_worker();
 //!
-//! state.reset_sentence("京都東京都").unwrap();
-//! tokenizer.tokenize(&mut state);
-//! assert_eq!(state.num_tokens(), 2);
+//! worker.reset_sentence("京都東京都").unwrap();
+//! worker.tokenize();
+//! assert_eq!(worker.num_tokens(), 2);
 //!
-//! let t0 = state.token(0);
+//! let t0 = worker.token(0);
 //! assert_eq!(t0.surface(), "京都");
 //! assert_eq!(t0.range_char(), 0..2);
 //! assert_eq!(t0.range_byte(), 0..6);
 //! assert_eq!(t0.feature(), "京都,名詞,固有名詞,地名,一般,*,*,キョウト,京都,*,A,*,*,*,1/5");
 //!
-//! let t1 = state.token(1);
+//! let t1 = worker.token(1);
 //! assert_eq!(t1.surface(), "東京都");
 //! assert_eq!(t1.range_char(), 2..5);
 //! assert_eq!(t1.range_byte(), 6..15);
@@ -49,10 +49,10 @@ pub mod common;
 pub mod dictionary;
 pub mod errors;
 mod sentence;
-pub mod state;
 pub mod token;
 pub mod tokenizer;
 mod utils;
+pub mod worker;
 
 #[cfg(test)]
 mod tests;

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -8,7 +8,6 @@
 //! ```
 //! use std::fs::File;
 //! use std::io::{BufRead, BufReader};
-//! use std::ops::Deref;
 //!
 //! use vibrato::{Dictionary, Tokenizer};
 //!
@@ -22,19 +21,21 @@
     doc = "let dict = Dictionary::read(BufReader::new(file)).unwrap();"
 )]
 //!
-//! let mut tokenizer = vibrato::Tokenizer::new(&dict);
-//! let tokens = tokenizer.tokenize("京都東京都").unwrap();
+//! let tokenizer = vibrato::Tokenizer::new(dict);
+//! let mut state = tokenizer.new_state();
 //!
-//! assert_eq!(tokens.len(), 2);
+//! state.reset_sentence("京都東京都");
+//! tokenizer.tokenize(&mut state);
+//! assert_eq!(state.num_tokens(), 2);
 //!
-//! let t0 = tokens.get(0);
-//! assert_eq!(t0.surface().deref(), "京都");
+//! let t0 = state.token(0);
+//! assert_eq!(t0.surface(), "京都");
 //! assert_eq!(t0.range_char(), 0..2);
 //! assert_eq!(t0.range_byte(), 0..6);
 //! assert_eq!(t0.feature(), "京都,名詞,固有名詞,地名,一般,*,*,キョウト,京都,*,A,*,*,*,1/5");
 //!
-//! let t1 = tokens.get(1);
-//! assert_eq!(t1.surface().deref(), "東京都");
+//! let t1 = state.token(1);
+//! assert_eq!(t1.surface(), "東京都");
 //! assert_eq!(t1.range_char(), 2..5);
 //! assert_eq!(t1.range_byte(), 6..15);
 //! assert_eq!(t1.feature(), "東京都,名詞,固有名詞,地名,一般,*,*,トウキョウト,東京都,*,B,5/9,*,5/9,*");
@@ -48,6 +49,7 @@ pub mod common;
 pub mod dictionary;
 pub mod errors;
 mod sentence;
+pub mod state;
 pub mod token;
 pub mod tokenizer;
 mod utils;

--- a/vibrato/src/state.rs
+++ b/vibrato/src/state.rs
@@ -1,0 +1,100 @@
+//! Maintainer of an input sentence and tokenized results.
+use crate::dictionary::mapper::{ConnIdCounter, ConnIdProbs};
+use crate::dictionary::Dictionary;
+use crate::errors::Result;
+use crate::sentence::Sentence;
+use crate::token::{Token, TokenIter};
+use crate::tokenizer::lattice::{Lattice, Node};
+
+/// Maintainer of an input sentence and tokenized results.
+///
+/// It also holds the internal data structures used for tokenization,
+/// which can be reused to avoid unnecessary memory reallocation.
+pub struct State<'a> {
+    pub(crate) dict: &'a Dictionary,
+    pub(crate) sent: Sentence,
+    pub(crate) lattice: Lattice,
+    pub(crate) top_nodes: Vec<(u16, Node)>,
+    pub(crate) counter: Option<ConnIdCounter>,
+}
+
+impl<'a> State<'a> {
+    /// Creates a new instance.
+    pub(crate) fn new(dict: &'a Dictionary) -> Self {
+        Self {
+            dict,
+            sent: Sentence::new(),
+            lattice: Lattice::default(),
+            top_nodes: vec![],
+            counter: None,
+        }
+    }
+
+    /// Resets the input sentence to be tokenized.
+    ///
+    /// # Errors
+    ///
+    /// When the input text includes characters more than [`MAX_SENTENCE_LENGTH`],
+    /// an error will be returned.
+    pub fn reset_sentence<S>(&mut self, input: S) -> Result<()>
+    where
+        S: AsRef<str>,
+    {
+        self.sent.clear();
+        self.top_nodes.clear();
+        let input = input.as_ref();
+        if !input.is_empty() {
+            self.sent.set_sentence(input);
+            self.sent.compile(self.dict.char_prop())?;
+        }
+        Ok(())
+    }
+
+    /// Gets the number of tokens.
+    #[inline(always)]
+    pub fn num_tokens(&self) -> usize {
+        self.top_nodes.len()
+    }
+
+    /// Gets the `i`-th token.
+    #[inline(always)]
+    pub fn token(&self, i: usize) -> Token {
+        let index = self.num_tokens() - i - 1;
+        Token::new(self, index)
+    }
+
+    /// Creates an iterator of tokens.
+    #[inline(always)]
+    pub const fn token_iter(&'a self) -> TokenIter<'a> {
+        TokenIter::new(self, 0)
+    }
+
+    /// Initializes a counter to train occurrence probabilities of connection ids.
+    pub fn init_connid_counter(&mut self) {
+        let connector = self.dict.connector();
+        self.counter = Some(ConnIdCounter::new(
+            connector.num_left(),
+            connector.num_right(),
+        ));
+    }
+
+    /// Updates frequencies of connection ids at the last tokenization.
+    ///
+    /// # Panics
+    ///
+    /// It will panic when [`init_connid_counter()`] has never been called.
+    pub fn update_connid_counts(&mut self) {
+        self.lattice
+            .add_connid_counts(self.counter.as_mut().unwrap());
+    }
+
+    /// Computes the trained occurrence probabilities of connection ids,
+    /// returning those for left ids and right ids.
+    ///
+    /// # Panics
+    ///
+    /// It will panic when [`init_connid_counter()`] has never been called.
+    pub fn compute_connid_probs(&self) -> (ConnIdProbs, ConnIdProbs) {
+        self.counter.as_ref().unwrap().compute_probs()
+    }
+}

--- a/vibrato/src/state.rs
+++ b/vibrato/src/state.rs
@@ -8,7 +8,7 @@ use crate::tokenizer::lattice::{Lattice, Node};
 
 /// Maintainer of an input sentence and tokenized results.
 ///
-/// It also holds the internal data structures used for tokenization,
+/// It also holds the internal data structures used in tokenization,
 /// which can be reused to avoid unnecessary memory reallocation.
 pub struct State<'a> {
     pub(crate) dict: &'a Dictionary,
@@ -34,7 +34,8 @@ impl<'a> State<'a> {
     ///
     /// # Errors
     ///
-    /// When the input text includes characters more than [`MAX_SENTENCE_LENGTH`],
+    /// When the input sentence includes characters more than
+    /// [`MAX_SENTENCE_LENGTH`](crate::common::MAX_SENTENCE_LENGTH),
     /// an error will be returned.
     pub fn reset_sentence<S>(&mut self, input: S) -> Result<()>
     where
@@ -50,20 +51,20 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    /// Gets the number of tokens.
+    /// Gets the number of resultant tokens.
     #[inline(always)]
     pub fn num_tokens(&self) -> usize {
         self.top_nodes.len()
     }
 
-    /// Gets the `i`-th token.
+    /// Gets the `i`-th resultant token.
     #[inline(always)]
     pub fn token(&self, i: usize) -> Token {
         let index = self.num_tokens() - i - 1;
         Token::new(self, index)
     }
 
-    /// Creates an iterator of tokens.
+    /// Creates an iterator of resultant tokens.
     #[inline(always)]
     pub const fn token_iter(&'a self) -> TokenIter<'a> {
         TokenIter::new(self, 0)
@@ -82,18 +83,18 @@ impl<'a> State<'a> {
     ///
     /// # Panics
     ///
-    /// It will panic when [`init_connid_counter()`] has never been called.
+    /// It will panic when [`Self::init_connid_counter()`] has never been called.
     pub fn update_connid_counts(&mut self) {
         self.lattice
             .add_connid_counts(self.counter.as_mut().unwrap());
     }
 
     /// Computes the trained occurrence probabilities of connection ids,
-    /// returning those for left ids and right ids.
+    /// returning those for left- and right-ids.
     ///
     /// # Panics
     ///
-    /// It will panic when [`init_connid_counter()`] has never been called.
+    /// It will panic when [`Self::init_connid_counter()`] has never been called.
     pub fn compute_connid_probs(&self) -> (ConnIdProbs, ConnIdProbs) {
         self.counter.as_ref().unwrap().compute_probs()
     }

--- a/vibrato/src/tests/tokenizer.rs
+++ b/vibrato/src/tests/tokenizer.rs
@@ -18,14 +18,13 @@ fn test_tokenize_tokyo() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("東京都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("東京都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 0..3);
         assert_eq!(t.range_byte(), 0..9);
@@ -39,7 +38,7 @@ fn test_tokenize_tokyo() {
     //  [BOS] -- [東京都] -- [EOS]
     //     r=0  l=6   r=8  l=0
     //      c=-79
-    assert_eq!(state.token(0).total_cost(), -79 + 5320);
+    assert_eq!(worker.token(0).total_cost(), -79 + 5320);
 }
 
 #[test]
@@ -53,14 +52,13 @@ fn test_tokenize_kyotokyo() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("京都東京都京都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 3);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("京都東京都京都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 3);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "京都");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
@@ -70,7 +68,7 @@ fn test_tokenize_kyotokyo() {
         );
     }
     {
-        let t = state.token(1);
+        let t = worker.token(1);
         assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 2..5);
         assert_eq!(t.range_byte(), 6..15);
@@ -80,7 +78,7 @@ fn test_tokenize_kyotokyo() {
         );
     }
     {
-        let t = state.token(2);
+        let t = worker.token(2);
         assert_eq!(t.surface(), "京都");
         assert_eq!(t.range_char(), 5..7);
         assert_eq!(t.range_byte(), 15..21);
@@ -94,14 +92,14 @@ fn test_tokenize_kyotokyo() {
     //  [BOS] -- [京都] -- [東京都] -- [京都] -- [EOS]
     //     r=0  l=6  r=6  l=6  r=8  l=6  r=6  l=0
     //      c=-79     c=569     c=-352
-    assert_eq!(state.token(0).total_cost(), -79 + 5293);
+    assert_eq!(worker.token(0).total_cost(), -79 + 5293);
     assert_eq!(
-        state.token(1).total_cost(),
-        state.token(0).total_cost() + 569 + 5320
+        worker.token(1).total_cost(),
+        worker.token(0).total_cost() + 569 + 5320
     );
     assert_eq!(
-        state.token(2).total_cost(),
-        state.token(1).total_cost() - 352 + 5293
+        worker.token(2).total_cost(),
+        worker.token(1).total_cost() - 352 + 5293
     );
 }
 
@@ -118,21 +116,20 @@ fn test_tokenize_kyotokyo_with_user() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("京都東京都京都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 2);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("京都東京都京都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 2);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "京都東京都");
         assert_eq!(t.range_char(), 0..5);
         assert_eq!(t.range_byte(), 0..15);
         assert_eq!(t.feature(), "カスタム名詞");
     }
     {
-        let t = state.token(1);
+        let t = worker.token(1);
         assert_eq!(t.surface(), "京都");
         assert_eq!(t.range_char(), 5..7);
         assert_eq!(t.range_byte(), 15..21);
@@ -146,10 +143,10 @@ fn test_tokenize_kyotokyo_with_user() {
     //  [BOS] -- [京都東京都] -- [京都] -- [EOS]
     //     r=0  l=6      r=8  l=6  r=6  l=0
     //      c=-79         c=-352
-    assert_eq!(state.token(0).total_cost(), -79 - 1000);
+    assert_eq!(worker.token(0).total_cost(), -79 - 1000);
     assert_eq!(
-        state.token(1).total_cost(),
-        state.token(0).total_cost() - 352 + 5293
+        worker.token(1).total_cost(),
+        worker.token(0).total_cost() - 352 + 5293
     );
 }
 
@@ -164,14 +161,13 @@ fn test_tokenize_tokyoto_with_space() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("東京 都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 3);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("東京 都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 3);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "東京");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
@@ -181,14 +177,14 @@ fn test_tokenize_tokyoto_with_space() {
         );
     }
     {
-        let t = state.token(1);
+        let t = worker.token(1);
         assert_eq!(t.surface(), " ");
         assert_eq!(t.range_char(), 2..3);
         assert_eq!(t.range_byte(), 6..7);
         assert_eq!(t.feature(), " ,空白,*,*,*,*,*, , ,*,A,*,*,*,*");
     }
     {
-        let t = state.token(2);
+        let t = worker.token(2);
         assert_eq!(t.surface(), "都");
         assert_eq!(t.range_char(), 3..4);
         assert_eq!(t.range_byte(), 7..10);
@@ -199,14 +195,14 @@ fn test_tokenize_tokyoto_with_space() {
     //  [BOS] -- [東京] -- [ ] -- [都] -- [EOS]
     //     r=0  l=6 r=6 l=8 r=8 l=8 r=8 l=0
     //      c=-79    c=-390  c=1134  c=-522
-    assert_eq!(state.token(0).total_cost(), -79 + 2816);
+    assert_eq!(worker.token(0).total_cost(), -79 + 2816);
     assert_eq!(
-        state.token(1).total_cost(),
-        state.token(0).total_cost() - 390 - 20000
+        worker.token(1).total_cost(),
+        worker.token(0).total_cost() - 390 - 20000
     );
     assert_eq!(
-        state.token(2).total_cost(),
-        state.token(1).total_cost() + 1134 + 2914
+        worker.token(2).total_cost(),
+        worker.token(1).total_cost() + 1134 + 2914
     );
 }
 
@@ -221,14 +217,13 @@ fn test_tokenize_tokyoto_with_space_ignored() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("東京 都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 2);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("東京 都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 2);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "東京");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
@@ -238,7 +233,7 @@ fn test_tokenize_tokyoto_with_space_ignored() {
         );
     }
     {
-        let t = state.token(1);
+        let t = worker.token(1);
         assert_eq!(t.surface(), "都");
         assert_eq!(t.range_char(), 3..4);
         assert_eq!(t.range_byte(), 7..10);
@@ -249,10 +244,10 @@ fn test_tokenize_tokyoto_with_space_ignored() {
     //  [BOS] -- [東京] -- [都] -- [EOS]
     //     r=0  l=6 r=6  l=8 r=8 l=0
     //      c=-79    c=-390  c=-522
-    assert_eq!(state.token(0).total_cost(), -79 + 2816);
+    assert_eq!(worker.token(0).total_cost(), -79 + 2816);
     assert_eq!(
-        state.token(1).total_cost(),
-        state.token(0).total_cost() - 390 + 2914
+        worker.token(1).total_cost(),
+        worker.token(0).total_cost() - 390 + 2914
     );
 }
 
@@ -267,14 +262,13 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("東京   都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 2);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("東京   都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 2);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "東京");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
@@ -284,7 +278,7 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
         );
     }
     {
-        let t = state.token(1);
+        let t = worker.token(1);
         assert_eq!(t.surface(), "都");
         assert_eq!(t.range_char(), 5..6);
         assert_eq!(t.range_byte(), 9..12);
@@ -295,10 +289,10 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
     //  [BOS] -- [東京] -- [都] -- [EOS]
     //     r=0  l=6 r=6  l=8 r=8 l=0
     //      c=-79    c=-390  c=-522
-    assert_eq!(state.token(0).total_cost(), -79 + 2816);
+    assert_eq!(worker.token(0).total_cost(), -79 + 2816);
     assert_eq!(
-        state.token(1).total_cost(),
-        state.token(0).total_cost() - 390 + 2914
+        worker.token(1).total_cost(),
+        worker.token(0).total_cost() - 390 + 2914
     );
 }
 
@@ -313,14 +307,13 @@ fn test_tokenize_tokyoto_startswith_spaces_ignored() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("   東京都").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("   東京都").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 3..6);
         assert_eq!(t.range_byte(), 3..12);
@@ -334,7 +327,7 @@ fn test_tokenize_tokyoto_startswith_spaces_ignored() {
     //  [BOS] -- [東京都] -- [EOS]
     //     r=0  l=6   r=8  l=0
     //      c=-79
-    assert_eq!(state.token(0).total_cost(), -79 + 5320);
+    assert_eq!(worker.token(0).total_cost(), -79 + 5320);
 }
 
 #[test]
@@ -348,14 +341,13 @@ fn test_tokenize_tokyoto_endswith_spaces_ignored() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("東京都   ").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("東京都   ").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 0..3);
         assert_eq!(t.range_byte(), 0..9);
@@ -369,7 +361,7 @@ fn test_tokenize_tokyoto_endswith_spaces_ignored() {
     //  [BOS] -- [東京都] -- [EOS]
     //     r=0  l=6   r=8  l=0
     //      c=-79
-    assert_eq!(state.token(0).total_cost(), -79 + 5320);
+    assert_eq!(worker.token(0).total_cost(), -79 + 5320);
 }
 
 #[test]
@@ -383,14 +375,13 @@ fn test_tokenize_kampersanda() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("kampersanda").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("kampersanda").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "kampersanda");
         assert_eq!(t.range_char(), 0..11);
         assert_eq!(t.range_byte(), 0..11);
@@ -401,7 +392,7 @@ fn test_tokenize_kampersanda() {
     //  [BOS] -- [kampersanda] -- [EOS]
     //     r=0  l=7         r=7  l=0
     //      c=887
-    assert_eq!(state.token(0).total_cost(), 887 + 11633);
+    assert_eq!(worker.token(0).total_cost(), 887 + 11633);
 }
 
 #[test]
@@ -417,14 +408,13 @@ fn test_tokenize_kampersanda_with_user() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("kampersanda").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("kampersanda").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "kampersanda");
         assert_eq!(t.range_char(), 0..11);
         assert_eq!(t.range_byte(), 0..11);
@@ -435,7 +425,7 @@ fn test_tokenize_kampersanda_with_user() {
     //  [BOS] -- [kampersanda] -- [EOS]
     //     r=0  l=7         r=7  l=0
     //      c=887
-    assert_eq!(state.token(0).total_cost(), 887 - 2000);
+    assert_eq!(worker.token(0).total_cost(), 887 - 2000);
 }
 
 #[test]
@@ -452,21 +442,20 @@ fn test_tokenize_kampersanda_with_max_grouping() {
         .ignore_space(true)
         .unwrap()
         .max_grouping_len(9);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("kampersanda").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 2);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("kampersanda").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 2);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "k");
         assert_eq!(t.range_char(), 0..1);
         assert_eq!(t.range_byte(), 0..1);
         assert_eq!(t.feature(), "名詞,普通名詞,一般,*,*,*");
     }
     {
-        let t = state.token(1);
+        let t = worker.token(1);
         assert_eq!(t.surface(), "ampersanda");
         assert_eq!(t.range_char(), 1..11);
         assert_eq!(t.range_byte(), 1..11);
@@ -477,10 +466,10 @@ fn test_tokenize_kampersanda_with_max_grouping() {
     //  [BOS] -- [k] -- [ampersanda] -- [EOS]
     //     r=0 l=7 r=7 l=7        r=7  l=0
     //      c=887   c=2341
-    assert_eq!(state.token(0).total_cost(), 887 + 11633);
+    assert_eq!(worker.token(0).total_cost(), 887 + 11633);
     assert_eq!(
-        state.token(1).total_cost(),
-        state.token(0).total_cost() + 2341 + 11633
+        worker.token(1).total_cost(),
+        worker.token(0).total_cost() + 2341 + 11633
     );
 }
 
@@ -495,11 +484,10 @@ fn test_tokenize_tokyoken() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("東京県に行く").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 4);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("東京県に行く").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 4);
 }
 
 /// This test is to check if the category order in char.def is preserved.
@@ -514,14 +502,13 @@ fn test_tokenize_kanjinumeric() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("一橋大学大学院").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("一橋大学大学院").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
     {
-        let t = state.token(0);
+        let t = worker.token(0);
         assert_eq!(t.surface(), "一橋大学大学院");
         assert_eq!(t.range_char(), 0..7);
         assert_eq!(t.range_byte(), 0..21);
@@ -540,11 +527,10 @@ fn test_tokenize_empty() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
-
-    state.reset_sentence("").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 0);
+    let mut worker = tokenizer.new_worker();
+    worker.reset_sentence("").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 0);
 }
 
 #[test]
@@ -558,21 +544,21 @@ fn test_tokenize_repeat() {
     .unwrap();
 
     let tokenizer = Tokenizer::new(dict);
-    let mut state = tokenizer.new_state();
+    let mut worker = tokenizer.new_worker();
 
-    state.reset_sentence("東京に行く").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 3);
+    worker.reset_sentence("東京に行く").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 3);
 
-    state.reset_sentence("一橋大学大学院").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    worker.reset_sentence("一橋大学大学院").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 
-    state.reset_sentence("").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 0);
+    worker.reset_sentence("").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 0);
 
-    state.reset_sentence("kampersanda").unwrap();
-    tokenizer.tokenize(&mut state);
-    assert_eq!(state.num_tokens(), 1);
+    worker.reset_sentence("kampersanda").unwrap();
+    worker.tokenize();
+    assert_eq!(worker.num_tokens(), 1);
 }

--- a/vibrato/src/tests/tokenizer.rs
+++ b/vibrato/src/tests/tokenizer.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::dictionary::Dictionary;
 use crate::Tokenizer;
 
@@ -19,13 +17,16 @@ fn test_tokenize_tokyo() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("東京都").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 1);
+    state.reset_sentence("東京都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "東京都");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 0..3);
         assert_eq!(t.range_byte(), 0..9);
         assert_eq!(
@@ -38,7 +39,7 @@ fn test_tokenize_tokyo() {
     //  [BOS] -- [東京都] -- [EOS]
     //     r=0  l=6   r=8  l=0
     //      c=-79
-    assert_eq!(tokens.get(0).total_cost(), -79 + 5320);
+    assert_eq!(state.token(0).total_cost(), -79 + 5320);
 }
 
 #[test]
@@ -51,13 +52,16 @@ fn test_tokenize_kyotokyo() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("京都東京都京都").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 3);
+    state.reset_sentence("京都東京都京都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 3);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "京都");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "京都");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
         assert_eq!(
@@ -66,8 +70,8 @@ fn test_tokenize_kyotokyo() {
         );
     }
     {
-        let t = tokens.get(1);
-        assert_eq!(t.surface().deref(), "東京都");
+        let t = state.token(1);
+        assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 2..5);
         assert_eq!(t.range_byte(), 6..15);
         assert_eq!(
@@ -76,8 +80,8 @@ fn test_tokenize_kyotokyo() {
         );
     }
     {
-        let t = tokens.get(2);
-        assert_eq!(t.surface().deref(), "京都");
+        let t = state.token(2);
+        assert_eq!(t.surface(), "京都");
         assert_eq!(t.range_char(), 5..7);
         assert_eq!(t.range_byte(), 15..21);
         assert_eq!(
@@ -90,14 +94,14 @@ fn test_tokenize_kyotokyo() {
     //  [BOS] -- [京都] -- [東京都] -- [京都] -- [EOS]
     //     r=0  l=6  r=6  l=6  r=8  l=6  r=6  l=0
     //      c=-79     c=569     c=-352
-    assert_eq!(tokens.get(0).total_cost(), -79 + 5293);
+    assert_eq!(state.token(0).total_cost(), -79 + 5293);
     assert_eq!(
-        tokens.get(1).total_cost(),
-        tokens.get(0).total_cost() + 569 + 5320
+        state.token(1).total_cost(),
+        state.token(0).total_cost() + 569 + 5320
     );
     assert_eq!(
-        tokens.get(2).total_cost(),
-        tokens.get(1).total_cost() - 352 + 5293
+        state.token(2).total_cost(),
+        state.token(1).total_cost() - 352 + 5293
     );
 }
 
@@ -113,20 +117,23 @@ fn test_tokenize_kyotokyo_with_user() {
     .user_lexicon_from_reader(Some(USER_CSV.as_bytes()))
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("京都東京都京都").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 2);
+    state.reset_sentence("京都東京都京都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 2);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "京都東京都");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "京都東京都");
         assert_eq!(t.range_char(), 0..5);
         assert_eq!(t.range_byte(), 0..15);
         assert_eq!(t.feature(), "カスタム名詞");
     }
     {
-        let t = tokens.get(1);
-        assert_eq!(t.surface().deref(), "京都");
+        let t = state.token(1);
+        assert_eq!(t.surface(), "京都");
         assert_eq!(t.range_char(), 5..7);
         assert_eq!(t.range_byte(), 15..21);
         assert_eq!(
@@ -139,10 +146,10 @@ fn test_tokenize_kyotokyo_with_user() {
     //  [BOS] -- [京都東京都] -- [京都] -- [EOS]
     //     r=0  l=6      r=8  l=6  r=6  l=0
     //      c=-79         c=-352
-    assert_eq!(tokens.get(0).total_cost(), -79 - 1000);
+    assert_eq!(state.token(0).total_cost(), -79 - 1000);
     assert_eq!(
-        tokens.get(1).total_cost(),
-        tokens.get(0).total_cost() - 352 + 5293
+        state.token(1).total_cost(),
+        state.token(0).total_cost() - 352 + 5293
     );
 }
 
@@ -156,13 +163,16 @@ fn test_tokenize_tokyoto_with_space() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("東京 都").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 3);
+    state.reset_sentence("東京 都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 3);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "東京");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "東京");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
         assert_eq!(
@@ -171,15 +181,15 @@ fn test_tokenize_tokyoto_with_space() {
         );
     }
     {
-        let t = tokens.get(1);
-        assert_eq!(t.surface().deref(), " ");
+        let t = state.token(1);
+        assert_eq!(t.surface(), " ");
         assert_eq!(t.range_char(), 2..3);
         assert_eq!(t.range_byte(), 6..7);
         assert_eq!(t.feature(), " ,空白,*,*,*,*,*, , ,*,A,*,*,*,*");
     }
     {
-        let t = tokens.get(2);
-        assert_eq!(t.surface().deref(), "都");
+        let t = state.token(2);
+        assert_eq!(t.surface(), "都");
         assert_eq!(t.range_char(), 3..4);
         assert_eq!(t.range_byte(), 7..10);
         assert_eq!(t.feature(), "都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*");
@@ -189,14 +199,14 @@ fn test_tokenize_tokyoto_with_space() {
     //  [BOS] -- [東京] -- [ ] -- [都] -- [EOS]
     //     r=0  l=6 r=6 l=8 r=8 l=8 r=8 l=0
     //      c=-79    c=-390  c=1134  c=-522
-    assert_eq!(tokens.get(0).total_cost(), -79 + 2816);
+    assert_eq!(state.token(0).total_cost(), -79 + 2816);
     assert_eq!(
-        tokens.get(1).total_cost(),
-        tokens.get(0).total_cost() - 390 - 20000
+        state.token(1).total_cost(),
+        state.token(0).total_cost() - 390 - 20000
     );
     assert_eq!(
-        tokens.get(2).total_cost(),
-        tokens.get(1).total_cost() + 1134 + 2914
+        state.token(2).total_cost(),
+        state.token(1).total_cost() + 1134 + 2914
     );
 }
 
@@ -210,13 +220,16 @@ fn test_tokenize_tokyoto_with_space_ignored() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict).ignore_space(true).unwrap();
-    let tokens = tokenizer.tokenize("東京 都").unwrap();
+    let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 2);
+    state.reset_sentence("東京 都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 2);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "東京");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "東京");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
         assert_eq!(
@@ -225,8 +238,8 @@ fn test_tokenize_tokyoto_with_space_ignored() {
         );
     }
     {
-        let t = tokens.get(1);
-        assert_eq!(t.surface().deref(), "都");
+        let t = state.token(1);
+        assert_eq!(t.surface(), "都");
         assert_eq!(t.range_char(), 3..4);
         assert_eq!(t.range_byte(), 7..10);
         assert_eq!(t.feature(), "都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*");
@@ -236,10 +249,10 @@ fn test_tokenize_tokyoto_with_space_ignored() {
     //  [BOS] -- [東京] -- [都] -- [EOS]
     //     r=0  l=6 r=6  l=8 r=8 l=0
     //      c=-79    c=-390  c=-522
-    assert_eq!(tokens.get(0).total_cost(), -79 + 2816);
+    assert_eq!(state.token(0).total_cost(), -79 + 2816);
     assert_eq!(
-        tokens.get(1).total_cost(),
-        tokens.get(0).total_cost() - 390 + 2914
+        state.token(1).total_cost(),
+        state.token(0).total_cost() - 390 + 2914
     );
 }
 
@@ -253,13 +266,16 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict).ignore_space(true).unwrap();
-    let tokens = tokenizer.tokenize("東京   都").unwrap();
+    let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 2);
+    state.reset_sentence("東京   都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 2);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "東京");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "東京");
         assert_eq!(t.range_char(), 0..2);
         assert_eq!(t.range_byte(), 0..6);
         assert_eq!(
@@ -268,8 +284,8 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
         );
     }
     {
-        let t = tokens.get(1);
-        assert_eq!(t.surface().deref(), "都");
+        let t = state.token(1);
+        assert_eq!(t.surface(), "都");
         assert_eq!(t.range_char(), 5..6);
         assert_eq!(t.range_byte(), 9..12);
         assert_eq!(t.feature(), "都,名詞,普通名詞,一般,*,*,*,ト,都,*,A,*,*,*,*");
@@ -279,10 +295,10 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
     //  [BOS] -- [東京] -- [都] -- [EOS]
     //     r=0  l=6 r=6  l=8 r=8 l=0
     //      c=-79    c=-390  c=-522
-    assert_eq!(tokens.get(0).total_cost(), -79 + 2816);
+    assert_eq!(state.token(0).total_cost(), -79 + 2816);
     assert_eq!(
-        tokens.get(1).total_cost(),
-        tokens.get(0).total_cost() - 390 + 2914
+        state.token(1).total_cost(),
+        state.token(0).total_cost() - 390 + 2914
     );
 }
 
@@ -296,13 +312,16 @@ fn test_tokenize_tokyoto_startswith_spaces_ignored() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict).ignore_space(true).unwrap();
-    let tokens = tokenizer.tokenize("   東京都").unwrap();
+    let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 1);
+    state.reset_sentence("   東京都").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "東京都");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 3..6);
         assert_eq!(t.range_byte(), 3..12);
         assert_eq!(
@@ -315,7 +334,7 @@ fn test_tokenize_tokyoto_startswith_spaces_ignored() {
     //  [BOS] -- [東京都] -- [EOS]
     //     r=0  l=6   r=8  l=0
     //      c=-79
-    assert_eq!(tokens.get(0).total_cost(), -79 + 5320);
+    assert_eq!(state.token(0).total_cost(), -79 + 5320);
 }
 
 #[test]
@@ -328,13 +347,16 @@ fn test_tokenize_tokyoto_endswith_spaces_ignored() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict).ignore_space(true).unwrap();
-    let tokens = tokenizer.tokenize("東京都   ").unwrap();
+    let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 1);
+    state.reset_sentence("東京都   ").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "東京都");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "東京都");
         assert_eq!(t.range_char(), 0..3);
         assert_eq!(t.range_byte(), 0..9);
         assert_eq!(
@@ -347,7 +369,7 @@ fn test_tokenize_tokyoto_endswith_spaces_ignored() {
     //  [BOS] -- [東京都] -- [EOS]
     //     r=0  l=6   r=8  l=0
     //      c=-79
-    assert_eq!(tokens.get(0).total_cost(), -79 + 5320);
+    assert_eq!(state.token(0).total_cost(), -79 + 5320);
 }
 
 #[test]
@@ -360,13 +382,16 @@ fn test_tokenize_kampersanda() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("kampersanda").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 1);
+    state.reset_sentence("kampersanda").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "kampersanda");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "kampersanda");
         assert_eq!(t.range_char(), 0..11);
         assert_eq!(t.range_byte(), 0..11);
         assert_eq!(t.feature(), "名詞,普通名詞,一般,*,*,*");
@@ -376,7 +401,7 @@ fn test_tokenize_kampersanda() {
     //  [BOS] -- [kampersanda] -- [EOS]
     //     r=0  l=7         r=7  l=0
     //      c=887
-    assert_eq!(tokens.get(0).total_cost(), 887 + 11633);
+    assert_eq!(state.token(0).total_cost(), 887 + 11633);
 }
 
 #[test]
@@ -391,13 +416,16 @@ fn test_tokenize_kampersanda_with_user() {
     .user_lexicon_from_reader(Some(USER_CSV.as_bytes()))
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("kampersanda").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 1);
+    state.reset_sentence("kampersanda").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "kampersanda");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "kampersanda");
         assert_eq!(t.range_char(), 0..11);
         assert_eq!(t.range_byte(), 0..11);
         assert_eq!(t.feature(), "カスタム名詞");
@@ -407,7 +435,7 @@ fn test_tokenize_kampersanda_with_user() {
     //  [BOS] -- [kampersanda] -- [EOS]
     //     r=0  l=7         r=7  l=0
     //      c=887
-    assert_eq!(tokens.get(0).total_cost(), 887 - 2000);
+    assert_eq!(state.token(0).total_cost(), 887 - 2000);
 }
 
 #[test]
@@ -420,23 +448,26 @@ fn test_tokenize_kampersanda_with_max_grouping() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict)
+    let tokenizer = Tokenizer::new(dict)
         .ignore_space(true)
         .unwrap()
         .max_grouping_len(9);
-    let tokens = tokenizer.tokenize("kampersanda").unwrap();
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 2);
+    state.reset_sentence("kampersanda").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 2);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "k");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "k");
         assert_eq!(t.range_char(), 0..1);
         assert_eq!(t.range_byte(), 0..1);
         assert_eq!(t.feature(), "名詞,普通名詞,一般,*,*,*");
     }
     {
-        let t = tokens.get(1);
-        assert_eq!(t.surface().deref(), "ampersanda");
+        let t = state.token(1);
+        assert_eq!(t.surface(), "ampersanda");
         assert_eq!(t.range_char(), 1..11);
         assert_eq!(t.range_byte(), 1..11);
         assert_eq!(t.feature(), "名詞,普通名詞,一般,*,*,*");
@@ -446,10 +477,10 @@ fn test_tokenize_kampersanda_with_max_grouping() {
     //  [BOS] -- [k] -- [ampersanda] -- [EOS]
     //     r=0 l=7 r=7 l=7        r=7  l=0
     //      c=887   c=2341
-    assert_eq!(tokens.get(0).total_cost(), 887 + 11633);
+    assert_eq!(state.token(0).total_cost(), 887 + 11633);
     assert_eq!(
-        tokens.get(1).total_cost(),
-        tokens.get(0).total_cost() + 2341 + 11633
+        state.token(1).total_cost(),
+        state.token(0).total_cost() + 2341 + 11633
     );
 }
 
@@ -463,10 +494,12 @@ fn test_tokenize_tokyoken() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("東京県に行く").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 4);
+    state.reset_sentence("東京県に行く").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 4);
 }
 
 /// This test is to check if the category order in char.def is preserved.
@@ -480,13 +513,16 @@ fn test_tokenize_kanjinumeric() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("一橋大学大学院").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 1);
+    state.reset_sentence("一橋大学大学院").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
     {
-        let t = tokens.get(0);
-        assert_eq!(t.surface().deref(), "一橋大学大学院");
+        let t = state.token(0);
+        assert_eq!(t.surface(), "一橋大学大学院");
         assert_eq!(t.range_char(), 0..7);
         assert_eq!(t.range_byte(), 0..21);
         assert_eq!(t.feature(), "名詞,数,*,*,*,*,*");
@@ -503,8 +539,40 @@ fn test_tokenize_empty() {
     )
     .unwrap();
 
-    let mut tokenizer = Tokenizer::new(&dict);
-    let tokens = tokenizer.tokenize("").unwrap();
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
 
-    assert_eq!(tokens.len(), 0);
+    state.reset_sentence("").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 0);
+}
+
+#[test]
+fn test_tokenize_repeat() {
+    let dict = Dictionary::from_readers(
+        LEX_CSV.as_bytes(),
+        MATRIX_DEF.as_bytes(),
+        CHAR_DEF.as_bytes(),
+        UNK_DEF.as_bytes(),
+    )
+    .unwrap();
+
+    let tokenizer = Tokenizer::new(dict);
+    let mut state = tokenizer.new_state();
+
+    state.reset_sentence("東京に行く").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 3);
+
+    state.reset_sentence("一橋大学大学院").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
+
+    state.reset_sentence("").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 0);
+
+    state.reset_sentence("kampersanda").unwrap();
+    tokenizer.tokenize(&mut state);
+    assert_eq!(state.num_tokens(), 1);
 }

--- a/vibrato/src/token.rs
+++ b/vibrato/src/token.rs
@@ -81,6 +81,22 @@ impl<'a> Token<'a> {
     }
 }
 
+impl<'a> std::fmt::Debug for Token<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Token")
+            .field("surface", &self.surface())
+            .field("range_char", &self.range_char())
+            .field("range_byte", &self.range_byte())
+            .field("feature", &self.feature())
+            .field("lex_type", &self.lex_type())
+            .field("left_id", &self.left_id())
+            .field("right_id", &self.right_id())
+            .field("word_cost", &self.word_cost())
+            .field("total_cost", &self.total_cost())
+            .finish()
+    }
+}
+
 /// Iterator of tokens.
 pub struct TokenIter<'a> {
     state: &'a State<'a>,

--- a/vibrato/src/token.rs
+++ b/vibrato/src/token.rs
@@ -1,135 +1,97 @@
 //! Container of resultant tokens.
-use std::cell::{Ref, RefCell};
 use std::ops::Range;
-use std::rc::Rc;
 
-use crate::dictionary::{Dictionary, LexType};
-use crate::sentence::Sentence;
-use crate::tokenizer::Node;
+use crate::dictionary::LexType;
+use crate::state::State;
 
-/// List of tokens.
-pub struct TokenList<'a> {
-    pub(crate) dict: &'a Dictionary,
-    pub(crate) sent: Rc<RefCell<Sentence>>,
-    pub(crate) nodes: Vec<(u16, Node)>,
-}
-
-impl<'a> TokenList<'a> {
-    pub(crate) fn new(dict: &'a Dictionary) -> Self {
-        Self {
-            dict,
-            sent: Rc::default(),
-            nodes: vec![],
-        }
-    }
-
-    /// Gets the number of tokens.
-    #[inline(always)]
-    pub fn len(&self) -> usize {
-        self.nodes.len()
-    }
-
-    /// Checks if the list is empty.
-    #[inline(always)]
-    pub fn is_empty(&self) -> bool {
-        self.nodes.len() == 0
-    }
-
-    /// Creates an iterator of tokens.
-    #[inline(always)]
-    pub const fn iter(&'a self) -> TokenIter<'a> {
-        TokenIter { list: self, i: 0 }
-    }
-
-    /// Gets the `i`-th token.
-    #[inline(always)]
-    pub fn get(&self, i: usize) -> Token {
-        let index = self.index(i);
-        Token { list: self, index }
-    }
-
-    #[inline(always)]
-    fn index(&self, i: usize) -> usize {
-        self.nodes.len() - i - 1
-    }
-}
-
-/// Token.
+/// Resultant token.
 pub struct Token<'a> {
-    list: &'a TokenList<'a>,
+    state: &'a State<'a>,
     index: usize,
 }
 
 impl<'a> Token<'a> {
+    #[inline(always)]
+    pub(crate) const fn new(state: &'a State, index: usize) -> Self {
+        Self { state, index }
+    }
+
     /// Gets the position range of the token in characters.
     #[inline(always)]
     pub fn range_char(&self) -> Range<usize> {
-        let (end_word, node) = &self.list.nodes[self.index];
+        let (end_word, node) = &self.state.top_nodes[self.index];
         usize::from(node.start_word)..usize::from(*end_word)
     }
 
     /// Gets the position range of the token in bytes.
     #[inline(always)]
     pub fn range_byte(&self) -> Range<usize> {
-        let sent = self.list.sent.borrow();
-        let (end_word, node) = &self.list.nodes[self.index];
+        let sent = &self.state.sent;
+        let (end_word, node) = &self.state.top_nodes[self.index];
         sent.byte_position(node.start_word)..sent.byte_position(*end_word)
     }
 
     /// Gets the surface string of the token.
     #[inline(always)]
-    pub fn surface(&self) -> Ref<str> {
-        let sent = self.list.sent.borrow();
-        Ref::map(sent, |s| &s.raw()[self.range_byte()])
+    pub fn surface(&self) -> &str {
+        let sent = &self.state.sent;
+        &sent.raw()[self.range_byte()]
     }
 
     /// Gets the feature string of the token.
     #[inline(always)]
     pub fn feature(&self) -> &str {
-        let (_, node) = &self.list.nodes[self.index];
-        self.list.dict.word_feature(node.word_idx())
+        let (_, node) = &self.state.top_nodes[self.index];
+        self.state.dict.word_feature(node.word_idx())
     }
 
     /// Gets the lexicon type where the token is from.
     #[inline(always)]
     pub fn lex_type(&self) -> LexType {
-        let (_, node) = &self.list.nodes[self.index];
+        let (_, node) = &self.state.top_nodes[self.index];
         node.word_idx().lex_type
     }
 
     /// Gets the left id of the token's node.
     #[inline(always)]
     pub fn left_id(&self) -> u16 {
-        let (_, node) = &self.list.nodes[self.index];
+        let (_, node) = &self.state.top_nodes[self.index];
         node.left_id
     }
 
     /// Gets the right id of the token's node.
     #[inline(always)]
     pub fn right_id(&self) -> u16 {
-        let (_, node) = &self.list.nodes[self.index];
+        let (_, node) = &self.state.top_nodes[self.index];
         node.right_id
     }
 
     /// Gets the word cost of the token's node.
     #[inline(always)]
     pub fn word_cost(&self) -> i16 {
-        let (_, node) = &self.list.nodes[self.index];
-        self.list.dict.word_param(node.word_idx()).word_cost
+        let (_, node) = &self.state.top_nodes[self.index];
+        self.state.dict.word_param(node.word_idx()).word_cost
     }
 
     /// Gets the total cost from BOS to the token's node.
     #[inline(always)]
     pub fn total_cost(&self) -> i32 {
-        let (_, node) = &self.list.nodes[self.index];
+        let (_, node) = &self.state.top_nodes[self.index];
         node.min_cost
     }
 }
 
 /// Iterator of tokens.
 pub struct TokenIter<'a> {
-    list: &'a TokenList<'a>,
+    state: &'a State<'a>,
     i: usize,
+}
+
+impl<'a> TokenIter<'a> {
+    #[inline(always)]
+    pub(crate) const fn new(state: &'a State, i: usize) -> Self {
+        Self { state, i }
+    }
 }
 
 impl<'a> Iterator for TokenIter<'a> {
@@ -137,8 +99,8 @@ impl<'a> Iterator for TokenIter<'a> {
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.i < self.list.len() {
-            let t = self.list.get(self.i);
+        if self.i < self.state.num_tokens() {
+            let t = self.state.token(self.i);
             self.i += 1;
             Some(t)
         } else {
@@ -149,8 +111,6 @@ impl<'a> Iterator for TokenIter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Deref;
-
     use crate::dictionary::*;
     use crate::tokenizer::*;
 
@@ -173,15 +133,18 @@ mod tests {
         )
         .unwrap();
 
-        let mut tokenizer = Tokenizer::new(&dict);
-        let tokens = tokenizer.tokenize("自然言語処理").unwrap();
-        assert_eq!(tokens.len(), 2);
+        let tokenizer = Tokenizer::new(dict);
+        let mut state = tokenizer.new_state();
 
-        let mut it = tokens.iter();
-        for i in 0..tokens.len() {
-            let lhs = tokens.get(i);
+        state.reset_sentence("自然言語処理").unwrap();
+        tokenizer.tokenize(&mut state);
+        assert_eq!(state.num_tokens(), 2);
+
+        let mut it = state.token_iter();
+        for i in 0..state.num_tokens() {
+            let lhs = state.token(i);
             let rhs = it.next().unwrap();
-            assert_eq!(lhs.surface().deref(), rhs.surface().deref());
+            assert_eq!(lhs.surface(), rhs.surface());
         }
         assert!(it.next().is_none());
     }

--- a/vibrato/src/tokenizer.rs
+++ b/vibrato/src/tokenizer.rs
@@ -124,7 +124,7 @@ impl Tokenizer {
                 if let Some(user_lexicon) = self.dict.user_lexicon() {
                     for m in user_lexicon.common_prefix_iterator(suffix) {
                         debug_assert!(start_word + m.end_char <= input_len);
-                        self.lattice.insert_node(
+                        lattice.insert_node(
                             start_node,
                             start_word,
                             start_word + m.end_char,
@@ -226,8 +226,7 @@ impl Tokenizer {
             lattice.insert_eos(start_node, self.dict.connector());
         } else {
             unsafe {
-                lattice
-                    .insert_eos_unchecked(start_node, self.dict.connector());
+                lattice.insert_eos_unchecked(start_node, self.dict.connector());
             }
         }
     }


### PR DESCRIPTION
This PR implemented a stateless version of `Tokenizer` for multithreading.