### PR TITLE
Remove unchecked feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ $ echo '本とカレーの街神保町へようこそ。' | cargo run --release 
 本 と カレー の 街 神保 町 へ ようこそ 。
 ```
 
-## Faster tokenization
-
-If you can guarantee that `system.dic` is exported from this library,
-you can specify `--features=unchecked` for faster tokenization.
-
-```
-$ echo '本とカレーの街神保町へようこそ。' | cargo run --release -p tokenize --features=unchecked -- -i resources_ipadic-mecab-2_7_0/system.dic -O wakati
-```
-
 ## MeCab-compatible options
 
 Vibrato is a reimplementation of the MeCab algorithm,
@@ -172,6 +163,9 @@ EOS
 ## Benchmark
 
 You can measure the tokenization speed for sentences in `test.txt`.
+
+If you can guarantee that `system.dic` is exported from this library,
+you can specify `--features=unchecked` for faster tokenization.
 
 ```
 $ cargo run --release -p benchmark --features=unchecked -- -i resources_ipadic-mecab-2_7_0/system.dic < test.txt

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [features]
 default = []
-unchecked = ["vibrato/unchecked"]
 
 [dependencies]
 vibrato = { path = "../vibrato" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [features]
 default = []
 
+unchecked = []
+
 [dependencies]
 vibrato = { path = "../vibrato" }
 bincode = "2.0.0-rc.1"  # MIT

--- a/prepare/Cargo.toml
+++ b/prepare/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [features]
 default = []
-unchecked = ["vibrato/unchecked"]
 
 [dependencies]
 vibrato = { path = "../vibrato" }

--- a/prepare/src/train.rs
+++ b/prepare/src/train.rs
@@ -22,10 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     eprintln!("Loading the dictionary...");
     let reader = BufReader::new(File::open(args.sysdic_filename)?);
-    #[cfg(not(feature = "unchecked"))]
     let dict = Dictionary::read(reader)?;
-    #[cfg(feature = "unchecked")]
-    let dict = unsafe { Dictionary::read_unchecked(reader)? };
 
     eprintln!("Training connection id mappings...");
     let mut tokenizer = Tokenizer::new(&dict);

--- a/tokenize/Cargo.toml
+++ b/tokenize/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [features]
 default = []
-unchecked = ["vibrato/unchecked"]
 
 [dependencies]
 vibrato = { path = "../vibrato" }

--- a/tokenize/src/main.rs
+++ b/tokenize/src/main.rs
@@ -51,10 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     eprintln!("Loading the dictionary...");
     let reader = BufReader::new(File::open(args.sysdic_filename)?);
-    #[cfg(not(feature = "unchecked"))]
     let mut dict = Dictionary::read(reader)?;
-    #[cfg(feature = "unchecked")]
-    let mut dict = unsafe { Dictionary::read_unchecked(reader)? };
 
     if let Some(userlex_csv_filename) = args.userlex_csv_filename {
         dict = dict.user_lexicon_from_reader(Some(File::open(userlex_csv_filename)?))?;

--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -17,8 +17,3 @@ categories = ["text-processing"]
 bincode = "2.0.0-rc.1"  # MIT
 csv = "1.1"
 crawdad = "0.3.0"
-
-[features]
-default = []
-
-unchecked = []

--- a/vibrato/src/dictionary/builder.rs
+++ b/vibrato/src/dictionary/builder.rs
@@ -54,14 +54,17 @@ impl Dictionary {
             ));
         }
 
-        Ok(Self(DictionaryInner {
-            system_lexicon,
-            user_lexicon: None,
-            connector,
-            mapper: None,
-            char_prop,
-            unk_handler,
-        }))
+        Ok(Self {
+            data: DictionaryInner {
+                system_lexicon,
+                user_lexicon: None,
+                connector,
+                mapper: None,
+                char_prop,
+                unk_handler,
+            },
+            need_check: false,
+        })
     }
 
     /// Resets the user dictionary from a reader.
@@ -85,7 +88,7 @@ impl Dictionary {
     {
         if let Some(user_lexicon_rdr) = user_lexicon_rdr {
             let mut user_lexicon = Lexicon::from_reader(user_lexicon_rdr, LexType::User)?;
-            if let Some(mapper) = self.0.mapper.as_ref() {
+            if let Some(mapper) = self.data.mapper.as_ref() {
                 user_lexicon.do_mapping(mapper);
             }
             if !user_lexicon.verify(self.connector()) {
@@ -94,9 +97,9 @@ impl Dictionary {
                     "user_lexicon_rdr includes invalid connection ids.",
                 ));
             }
-            self.0.user_lexicon = Some(user_lexicon);
+            self.data.user_lexicon = Some(user_lexicon);
         } else {
-            self.0.user_lexicon = None;
+            self.data.user_lexicon = None;
         }
         Ok(self)
     }
@@ -121,13 +124,13 @@ impl Dictionary {
         R: IntoIterator<Item = u16>,
     {
         let mapper = ConnIdMapper::from_iter(lmap, rmap)?;
-        self.0.system_lexicon.do_mapping(&mapper);
-        if let Some(user_lexicon) = self.0.user_lexicon.as_mut() {
+        self.data.system_lexicon.do_mapping(&mapper);
+        if let Some(user_lexicon) = self.data.user_lexicon.as_mut() {
             user_lexicon.do_mapping(&mapper);
         }
-        self.0.connector.do_mapping(&mapper);
-        self.0.unk_handler.do_mapping(&mapper);
-        self.0.mapper = Some(mapper);
+        self.data.connector.do_mapping(&mapper);
+        self.data.unk_handler.do_mapping(&mapper);
+        self.data.mapper = Some(mapper);
         Ok(self)
     }
 }

--- a/vibrato/src/dictionary/connector.rs
+++ b/vibrato/src/dictionary/connector.rs
@@ -34,15 +34,15 @@ impl Connector {
     #[inline(always)]
     pub fn cost(&self, right_id: u16, left_id: u16) -> i16 {
         let index = self.index(right_id, left_id);
-        #[cfg(feature = "unchecked")]
-        unsafe {
-            // The tokenization time can be shortened by 5--10%.
-            *self.data.get_unchecked(index)
-        }
-        #[cfg(not(feature = "unchecked"))]
-        {
-            self.data[index]
-        }
+        self.data[index]
+    }
+
+    /// Gets the value of the connection matrix
+    #[inline(always)]
+    pub unsafe fn cost_unchecked(&self, right_id: u16, left_id: u16) -> i16 {
+        let index = self.index(right_id, left_id);
+        // The tokenization time can be shortened by 5--10%.
+        *self.data.get_unchecked(index)
     }
 
     /// Returns maximum number of left connection ID

--- a/vibrato/src/dictionary/lexicon.rs
+++ b/vibrato/src/dictionary/lexicon.rs
@@ -42,6 +42,22 @@ impl Lexicon {
             })
     }
 
+    #[inline(always)]
+    pub unsafe fn common_prefix_iterator_unchecked<'a>(
+        &'a self,
+        input: &'a [char],
+    ) -> impl Iterator<Item = LexMatch> + 'a {
+        self.map
+            .common_prefix_iterator_unchecked(input)
+            .map(move |(word_id, end_char)| {
+                LexMatch::new(
+                    WordIdx::new(self.lex_type, word_id),
+                    self.params.get(usize::from_u32(word_id)),
+                    end_char,
+                )
+            })
+    }
+
     /// Do NOT make this function public to maintain consistency in
     /// the connection-id mapping among members of `Dictionary`.
     /// The consistency is managed in `Dictionary`.
@@ -119,7 +135,7 @@ mod tests {
             lex_type: LexType::System,
         };
         let input: Vec<_> = "東京都".chars().collect();
-        let mut it = lexicon.common_prefix_iterator(&input);
+        let mut it = lexicon.common_prefix_iterator_checked(&input);
         assert_eq!(
             it.next().unwrap(),
             LexMatch {

--- a/vibrato/src/dictionary/lexicon.rs
+++ b/vibrato/src/dictionary/lexicon.rs
@@ -135,7 +135,7 @@ mod tests {
             lex_type: LexType::System,
         };
         let input: Vec<_> = "東京都".chars().collect();
-        let mut it = lexicon.common_prefix_iterator_checked(&input);
+        let mut it = lexicon.common_prefix_iterator(&input);
         assert_eq!(
             it.next().unwrap(),
             LexMatch {

--- a/vibrato/src/dictionary/lexicon/map.rs
+++ b/vibrato/src/dictionary/lexicon/map.rs
@@ -40,6 +40,18 @@ impl WordMap {
                 .map(move |word_id| (word_id, e.end_char))
         })
     }
+
+    #[inline(always)]
+    pub unsafe fn common_prefix_iterator_unchecked<'a>(
+        &'a self,
+        input: &'a [char],
+    ) -> impl Iterator<Item = (u32, u16)> + 'a {
+        self.trie.common_prefix_iterator(input).flat_map(move |e| {
+            self.postings
+                .ids_unchecked(usize::from_u32(e.value))
+                .map(move |word_id| (word_id, e.end_char))
+        })
+    }
 }
 
 #[derive(Default)]

--- a/vibrato/src/dictionary/lexicon/map/posting.rs
+++ b/vibrato/src/dictionary/lexicon/map/posting.rs
@@ -17,15 +17,14 @@ impl Postings {
     #[inline(always)]
     pub fn ids(&'_ self, i: usize) -> impl Iterator<Item = u32> + '_ {
         let len = usize::from_u32(self.data[i]);
-        #[cfg(feature = "unchecked")]
-        unsafe {
-            // The tokenization time can be shortened by 10%.
-            self.data.get_unchecked(i + 1..i + 1 + len).iter().cloned()
-        }
-        #[cfg(not(feature = "unchecked"))]
-        {
-            self.data[i + 1..i + 1 + len].iter().cloned()
-        }
+        self.data[i + 1..i + 1 + len].iter().cloned()
+    }
+
+    #[inline(always)]
+    pub unsafe fn ids_unchecked(&'_ self, i: usize) -> impl Iterator<Item = u32> + '_ {
+        let len = usize::from_u32(self.data[i]);
+        // The tokenization time can be shortened by 10%.
+        self.data.get_unchecked(i + 1..i + 1 + len).iter().cloned()
     }
 }
 

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -13,14 +13,7 @@
 //! use vibrato::{Dictionary, Tokenizer};
 //!
 //! let file = File::open("src/tests/resources/system.dic").unwrap();
-#![cfg_attr(
-    feature = "unchecked",
-    doc = "let dict = unsafe { Dictionary::read_unchecked(BufReader::new(file)).unwrap() };"
-)]
-#![cfg_attr(
-    not(feature = "unchecked"),
-    doc = "let dict = Dictionary::read(BufReader::new(file)).unwrap();"
-)]
+//! let dict = Dictionary::read(BufReader::new(file)).unwrap();"
 //!
 //! let mut tokenizer = vibrato::Tokenizer::new(&dict);
 //! let tokens = tokenizer.tokenize("京都東京都").unwrap();

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -13,7 +13,7 @@
 //! use vibrato::{Dictionary, Tokenizer};
 //!
 //! let file = File::open("src/tests/resources/system.dic").unwrap();
-//! let dict = Dictionary::read(BufReader::new(file)).unwrap();"
+//! let dict = Dictionary::read(BufReader::new(file)).unwrap();
 //!
 //! let mut tokenizer = vibrato::Tokenizer::new(&dict);
 //! let tokens = tokenizer.tokenize("京都東京都").unwrap();


### PR DESCRIPTION
This PR removes `unchecked` feature from this crate and adds some `unsafe` functions.

The current `unchecked` feature disables `Dictionary::read()`. Features may add functions, but should not remove. Also, `Dictionary::read()` will not be shown in docs.rs because the document will be built by the following command:
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```

This branch adds the `need_check` flag to `Dictionary` and switches functions according to that flag.