### PR TITLE
Move csv parsing into Lexicon

### DIFF
--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["text-processing"]
 [dependencies]
 bincode = "2.0.0-rc.1"  # MIT
 crawdad = "0.3.0"  # MIT or Apache-2.0
-csv = "1.1"  # Unlicense or MIT
 csv-core = "0.1.10"  # Unlicense or MIT
 hashbrown = "0.12"  # MIT or Apache-2.0
 regex = "1"  # MIT or Apache-2.0

--- a/vibrato/src/dictionary/lexicon.rs
+++ b/vibrato/src/dictionary/lexicon.rs
@@ -111,10 +111,10 @@ impl LexMatch {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct RawWordEntry {
+pub struct RawWordEntry<'a> {
     pub surface: String,
     pub param: WordParam,
-    pub feature: String,
+    pub feature: &'a str,
 }
 
 #[cfg(test)]

--- a/vibrato/src/dictionary/lexicon/builder.rs
+++ b/vibrato/src/dictionary/lexicon/builder.rs
@@ -98,11 +98,18 @@ impl Lexicon {
                     return Err(VibratoError::invalid_format(name, msg));
                 }
                 let feature = std::str::from_utf8(&features_bytes[..features_len - 1])?;
-                entries.push(RawWordEntry {
-                    surface,
-                    param: WordParam::new(left_id, right_id, word_cost),
-                    feature,
-                });
+                if surface.is_empty() {
+                    eprintln!(
+                        "Skipped an empty surface, {:?}",
+                        std::str::from_utf8(&record_bytes[..record_end_pos])?,
+                    );
+                } else {
+                    entries.push(RawWordEntry {
+                        surface,
+                        param: WordParam::new(left_id, right_id, word_cost),
+                        feature,
+                    });
+                }
                 surface = String::new();
                 field_cnt = 0;
                 record_end_pos = 0;
@@ -139,6 +146,13 @@ mod tests {
         assert_eq!(lex.features.get(0), "sizen");
         assert_eq!(lex.features.get(1), "gengo,げんご");
         assert_eq!(lex.lex_type, LexType::User);
+    }
+
+    #[test]
+    fn test_empty_surface() {
+        let data = "自然,0,2,1,sizen\n,1,0,-4,gengo,げんご";
+        let result = Lexicon::parse_csv(data.as_bytes(), "test").unwrap();
+        assert_eq!(result.len(), 1);
     }
 
     #[test]

--- a/vibrato/src/dictionary/lexicon/builder.rs
+++ b/vibrato/src/dictionary/lexicon/builder.rs
@@ -1,5 +1,7 @@
 use std::io::Read;
 
+use csv_core::ReadFieldResult;
+
 use crate::dictionary::lexicon::{
     LexType, Lexicon, RawWordEntry, WordFeatures, WordMap, WordParam, WordParams,
 };
@@ -7,25 +9,14 @@ use crate::errors::{Result, VibratoError};
 
 impl Lexicon {
     /// Builds a new instance from a lexicon file in the CSV format.
-    pub fn from_reader<R>(rdr: R, lex_type: LexType) -> Result<Self>
+    pub fn from_reader<R>(mut rdr: R, lex_type: LexType) -> Result<Self>
     where
         R: Read,
     {
-        let mut entries = vec![];
-        let mut reader = csv::ReaderBuilder::new()
-            .flexible(true)
-            .has_headers(false)
-            .from_reader(rdr); // automatically buffered
+        let mut buf = vec![];
+        rdr.read_to_end(&mut buf)?;
 
-        for (i, rec) in reader.records().enumerate() {
-            let rec = rec.map_err(|e| VibratoError::invalid_format("lex.csv", e.to_string()))?;
-            let e = Self::parse_csv(&rec)?;
-            if e.surface.is_empty() {
-                println!("Skipped an empty surface (at line {})", i);
-            } else {
-                entries.push(e);
-            }
-        }
+        let entries = Self::parse_csv(&buf, "lex.csv")?;
 
         let map = WordMap::new(entries.iter().map(|e| &e.surface))?;
         let params = WordParams::new(entries.iter().map(|e| e.param));
@@ -39,27 +30,88 @@ impl Lexicon {
         })
     }
 
-    fn parse_csv(rec: &csv::StringRecord) -> Result<RawWordEntry> {
-        if rec.len() < 4 {
-            let msg = format!(
-                "A csv row of lexicon must have four items at least, {:?}",
-                rec
-            );
-            return Err(VibratoError::invalid_format("lex.csv", msg));
+    pub(crate) fn parse_csv<'a>(
+        mut bytes: &'a [u8],
+        name: &'static str,
+    ) -> Result<Vec<RawWordEntry<'a>>> {
+        let mut entries = vec![];
+
+        let mut rdr = csv_core::Reader::new();
+        let mut features_bytes = bytes;
+        let mut record_bytes = bytes;
+        let mut field_cnt: usize = 0;
+        let mut features_len = 0;
+        let mut record_end_pos = 0;
+        let mut output = [0; 4096];
+
+        let mut surface = String::new();
+        let mut left_id = 0;
+        let mut right_id = 0;
+        let mut word_cost = 0;
+
+        loop {
+            let (result, nin, nout) = rdr.read_field(bytes, &mut output);
+            let record_end = match result {
+                ReadFieldResult::InputEmpty => {
+                    features_len += nin + 1;
+                    record_end_pos += nin;
+                    true
+                }
+                ReadFieldResult::OutputFull => {
+                    return Err(VibratoError::invalid_format(name, "Field too large"))
+                }
+                ReadFieldResult::Field { record_end } => {
+                    match field_cnt {
+                        0 => {
+                            surface = std::str::from_utf8(&output[..nout])?.to_string();
+                            record_bytes = bytes;
+                        }
+                        1 => {
+                            left_id = std::str::from_utf8(&output[..nout])?.parse()?;
+                        }
+                        2 => {
+                            right_id = std::str::from_utf8(&output[..nout])?.parse()?;
+                        }
+                        3 => {
+                            word_cost = std::str::from_utf8(&output[..nout])?.parse()?;
+                            features_bytes = &bytes[nin..];
+                            features_len = 0;
+                        }
+                        _ => {
+                            features_len += nin;
+                        }
+                    }
+                    record_end_pos += nin;
+                    record_end
+                }
+                ReadFieldResult::End => break,
+            };
+            if record_end {
+                if field_cnt == 0 && nin == 0 {
+                    continue;
+                }
+                if field_cnt <= 3 {
+                    let msg = format!(
+                        "A csv row of lexicon must have five items at least, {:?}",
+                        std::str::from_utf8(&record_bytes[..record_end_pos])?,
+                    );
+                    return Err(VibratoError::invalid_format(name, msg));
+                }
+                let feature = std::str::from_utf8(&features_bytes[..features_len - 1])?;
+                entries.push(RawWordEntry {
+                    surface,
+                    param: WordParam::new(left_id, right_id, word_cost),
+                    feature,
+                });
+                surface = String::new();
+                field_cnt = 0;
+                record_end_pos = 0;
+            } else {
+                field_cnt += 1;
+            }
+            bytes = &bytes[nin..];
         }
-
-        let mut iter = rec.iter();
-        let surface = iter.next().unwrap().to_string();
-        let left_id = iter.next().unwrap().parse()?;
-        let right_id = iter.next().unwrap().parse()?;
-        let word_cost = iter.next().unwrap().parse()?;
-        let feature = iter.collect::<Vec<_>>().join(",");
-
-        Ok(RawWordEntry {
-            surface,
-            param: WordParam::new(left_id, right_id, word_cost),
-            feature,
-        })
+        Ok(entries)
     }
 }
 
@@ -90,30 +142,30 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_few_cols() {
         let data = "自然,0,2";
-        Lexicon::from_reader(data.as_bytes(), LexType::System).unwrap();
+        let lex = Lexicon::from_reader(data.as_bytes(), LexType::System);
+        assert!(lex.is_err());
     }
 
     #[test]
-    #[should_panic]
     fn test_invalid_left_id() {
-        let data = "自然,-2,2,1";
-        Lexicon::from_reader(data.as_bytes(), LexType::System).unwrap();
+        let data = "自然,-2,2,1,a";
+        let lex = Lexicon::from_reader(data.as_bytes(), LexType::System);
+        assert!(lex.is_err());
     }
 
     #[test]
-    #[should_panic]
     fn test_invalid_right_id() {
-        let data = "自然,2,-2,1";
-        Lexicon::from_reader(data.as_bytes(), LexType::System).unwrap();
+        let data = "自然,2,-2,1,a";
+        let lex = Lexicon::from_reader(data.as_bytes(), LexType::System);
+        assert!(lex.is_err());
     }
 
     #[test]
-    #[should_panic]
     fn test_invalid_cost() {
-        let data = "自然,2,1,コスト";
-        Lexicon::from_reader(data.as_bytes(), LexType::System).unwrap();
+        let data = "自然,2,1,コスト,a";
+        let lex = Lexicon::from_reader(data.as_bytes(), LexType::System);
+        assert!(lex.is_err());
     }
 }

--- a/vibrato/src/dictionary/lexicon/feature.rs
+++ b/vibrato/src/dictionary/lexicon/feature.rs
@@ -14,7 +14,7 @@ impl WordFeatures {
         Self {
             features: features
                 .into_iter()
-                .map(|s| s.as_ref().to_owned())
+                .map(|s| s.as_ref().to_string())
                 .collect(),
         }
     }

--- a/vibrato/src/dictionary/lexicon/map.rs
+++ b/vibrato/src/dictionary/lexicon/map.rs
@@ -24,7 +24,7 @@ impl WordMap {
     {
         let mut b = WordMapBuilder::new();
         for (i, w) in words.into_iter().enumerate() {
-            b.add_record(w.as_ref().to_owned(), u32::try_from(i)?);
+            b.add_record(w.as_ref().to_string(), u32::try_from(i)?);
         }
         b.build()
     }

--- a/vibrato/src/errors.rs
+++ b/vibrato/src/errors.rs
@@ -29,6 +29,9 @@ pub enum VibratoError {
 
     /// The error variant for [`std::io::Error`].
     StdIo(std::io::Error),
+
+    /// The error variant for [`std::str::Utf8Error`].
+    Utf8(std::str::Utf8Error),
 }
 
 impl VibratoError {
@@ -63,6 +66,7 @@ impl fmt::Display for VibratoError {
             Self::BincodeDecode(e) => e.fmt(f),
             Self::BincodeEncode(e) => e.fmt(f),
             Self::StdIo(e) => e.fmt(f),
+            Self::Utf8(e) => e.fmt(f),
         }
     }
 }
@@ -132,5 +136,11 @@ impl From<bincode::error::EncodeError> for VibratoError {
 impl From<std::io::Error> for VibratoError {
     fn from(error: std::io::Error) -> Self {
         Self::StdIo(error)
+    }
+}
+
+impl From<std::str::Utf8Error> for VibratoError {
+    fn from(error: std::str::Utf8Error) -> Self {
+        Self::Utf8(error)
     }
 }


### PR DESCRIPTION
This PR moves the csv parser of the trainer into the lexicon module and uses this function from unk and lex parsers.

The previous implementation concatenates fields by `,`, but it may generate a wrong result as follows:
```
dictionary:
surf,1,2,3,feature1,"feature,2","""",""""

parsed:
["surf","1","2","3","feature1","feature,2","\"","\""]

output:
surf    feature1,feature,2,","
```

Instead, this branch only parses the first 4 cols and keeps the format of other fields.

In addittion, this branch replaces `#[should_panic]` to `is_err()` in some test cases.
`#[should_panic]` should not be used for testing error variants because it is unclear whether the function submits a panic or returns an error variant.
(There are many tests using `#[should_panic]`, so these tests should be corrected in another branch.)