### PR TITLE
Fix calculation of id-access probabilities

### DIFF
--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -96,3 +96,21 @@ impl ConnIdCounter {
         (lid_probs, rid_probs)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_probs() {
+        let mut counter = ConnIdCounter::new(3, 3);
+        counter.add(0, 1, 1);
+        counter.add(1, 0, 3);
+        counter.add(2, 1, 4);
+        counter.add(1, 1, 2);
+
+        let (lprobs, rprobs) = counter.compute_probs();
+        assert_eq!(lprobs, vec![(1, 5f64 / 10f64), (2, 4f64 / 10f64)]);
+        assert_eq!(rprobs, vec![(1, 7f64 / 10f64), (2, 0f64 / 10f64)]);
+    }
+}

--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -64,18 +64,20 @@ impl ConnIdCounter {
         let num_right = rid_count.len();
 
         // Compute Left-id probs
-        let mut lid_probs = Vec::with_capacity(num_left);
-        {
-            let acc = lid_count.iter().sum::<usize>() as f64;
-            for (lid, &cnt) in lid_count.iter().enumerate() {
-                let cnt = cnt as f64;
-                lid_probs.push((lid, cnt / acc));
-            }
-        }
+        let lid_sum = lid_count.iter().sum::<usize>() as f64;
+        let lid_probs: Vec<_> = lid_count
+            .iter()
+            .enumerate()
+            .map(|(lid, &cnt)| (lid, cnt as f64 / lid_sum))
+            .collect();
 
         // Compute Right-id probs
         let rid_sum = rid_count.iter().sum::<usize>() as f64;
-        let rid_probs: Vec<_> = rid_count.iter().enumerate().map(|(rid, &cnt)| (rid, cnt as f64 / rid_sum)).collect();
+        let rid_probs: Vec<_> = rid_count
+            .iter()
+            .enumerate()
+            .map(|(rid, &cnt)| (rid, cnt as f64 / rid_sum))
+            .collect();
 
         // Pop Id = 0
         assert_eq!(crate::common::BOS_EOS_CONNECTION_ID, 0);

--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -74,14 +74,8 @@ impl ConnIdCounter {
         }
 
         // Compute Right-id probs
-        let mut rid_probs = Vec::with_capacity(num_right);
-        {
-            let acc = rid_count.iter().sum::<usize>() as f64;
-            for (rid, &cnt) in rid_count.iter().enumerate() {
-                let cnt = cnt as f64;
-                rid_probs.push((rid, cnt / acc));
-            }
-        }
+        let rid_sum = rid_count.iter().sum::<usize>() as f64;
+        let rid_probs: Vec<_> = rid_count.iter().enumerate().map(|(rid, &cnt)| (rid, cnt as f64 / rid_sum)).collect();
 
         // Pop Id = 0
         assert_eq!(crate::common::BOS_EOS_CONNECTION_ID, 0);

--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -60,12 +60,9 @@ impl ConnIdCounter {
         let lid_count = &self.lid_count;
         let rid_count = &self.rid_count;
 
-        let num_left = lid_count.len();
-        let num_right = rid_count.len();
-
         // Compute Left-id probs
         let lid_sum = lid_count.iter().sum::<usize>() as f64;
-        let lid_probs: Vec<_> = lid_count
+        let mut lid_probs: Vec<_> = lid_count
             .iter()
             .enumerate()
             .map(|(lid, &cnt)| (lid, cnt as f64 / lid_sum))
@@ -73,7 +70,7 @@ impl ConnIdCounter {
 
         // Compute Right-id probs
         let rid_sum = rid_count.iter().sum::<usize>() as f64;
-        let rid_probs: Vec<_> = rid_count
+        let mut rid_probs: Vec<_> = rid_count
             .iter()
             .enumerate()
             .map(|(rid, &cnt)| (rid, cnt as f64 / rid_sum))

--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -104,13 +104,13 @@ mod tests {
     #[test]
     fn test_compute_probs() {
         let mut counter = ConnIdCounter::new(3, 3);
-        counter.add(0, 1, 1);
+        counter.add(0, 2, 1);
         counter.add(1, 0, 3);
-        counter.add(2, 1, 4);
-        counter.add(1, 1, 2);
+        counter.add(2, 2, 4);
+        counter.add(1, 2, 2);
 
         let (lprobs, rprobs) = counter.compute_probs();
         assert_eq!(lprobs, vec![(1, 5f64 / 10f64), (2, 4f64 / 10f64)]);
-        assert_eq!(rprobs, vec![(1, 7f64 / 10f64), (2, 0f64 / 10f64)]);
+        assert_eq!(rprobs, vec![(2, 7f64 / 10f64), (1, 0f64 / 10f64)]);
     }
 }

--- a/vibrato/src/dictionary/mapper.rs
+++ b/vibrato/src/dictionary/mapper.rs
@@ -36,60 +36,50 @@ pub type ConnIdProbs = Vec<(usize, f64)>;
 
 /// Counter to train mappings of connection ids.
 pub struct ConnIdCounter {
-    lid_to_rid_count: Vec<Vec<usize>>,
+    lid_count: Vec<usize>,
+    rid_count: Vec<usize>,
 }
 
 impl ConnIdCounter {
     /// Creates a new counter for the matrix of `num_left \times num_right`.
     pub fn new(num_left: usize, num_right: usize) -> Self {
         Self {
-            // The initial value 1 is for avoiding zero frequency.
-            lid_to_rid_count: vec![vec![1; num_right]; num_left],
+            lid_count: vec![0; num_left],
+            rid_count: vec![0; num_right],
         }
     }
 
     #[inline(always)]
     pub fn add(&mut self, left_id: u16, right_id: u16, num: usize) {
-        self.lid_to_rid_count[usize::from(left_id)][usize::from(right_id)] += num;
+        self.lid_count[usize::from(left_id)] += num;
+        self.rid_count[usize::from(right_id)] += num;
     }
 
     /// Computes the trained probabilities of connection ids.
     pub fn compute_probs(&self) -> (ConnIdProbs, ConnIdProbs) {
-        let lid_to_rid_count = &self.lid_to_rid_count;
+        let lid_count = &self.lid_count;
+        let rid_count = &self.rid_count;
 
-        let num_left = lid_to_rid_count.len();
-        let num_right = lid_to_rid_count[0].len();
+        let num_left = lid_count.len();
+        let num_right = rid_count.len();
 
         // Compute Left-id probs
         let mut lid_probs = Vec::with_capacity(num_left);
-        let mut lid_to_rid_probs = Vec::with_capacity(num_left);
-
-        for (lid, rid_count) in lid_to_rid_count.iter().enumerate() {
-            assert_eq!(num_right, rid_count.len());
-
-            let acc = rid_count.iter().sum::<usize>() as f64;
-            let mut probs = vec![0.0; num_right];
-            if acc != 0.0 {
-                for (rid, &cnt) in rid_count.iter().enumerate() {
-                    probs[rid] = cnt as f64 / acc;
-                }
+        {
+            let acc = lid_count.iter().sum::<usize>() as f64;
+            for (lid, &cnt) in lid_count.iter().enumerate() {
+                let cnt = cnt as f64;
+                lid_probs.push((lid, cnt / acc));
             }
-            lid_probs.push((lid, acc)); // ittan acc wo push suru
-            lid_to_rid_probs.push(probs);
-        }
-
-        let acc = lid_probs.iter().fold(0., |acc, &(_, cnt)| acc + cnt);
-        for (_, lp) in lid_probs.iter_mut() {
-            *lp /= acc;
         }
 
         // Compute Right-id probs
-        let mut rid_probs = vec![(0, 0.0); num_right];
-        for (i, (rid, rp)) in rid_probs.iter_mut().enumerate() {
-            *rid = i;
-            for lid in 0..num_left {
-                assert_eq!(lid, lid_probs[lid].0);
-                *rp += lid_probs[lid].1 * lid_to_rid_probs[lid][*rid];
+        let mut rid_probs = Vec::with_capacity(num_right);
+        {
+            let acc = rid_count.iter().sum::<usize>() as f64;
+            for (rid, &cnt) in rid_count.iter().enumerate() {
+                let cnt = cnt as f64;
+                rid_probs.push((rid, cnt / acc));
             }
         }
 


### PR DESCRIPTION
This PR fixed the calculation of left/right-id probabilities by removing unnecessary conditional formulations.