### PR TITLE
Bump up to 0.1.2

### DIFF
--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibrato"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Shunsuke Kanda <shnsk.knd@gmail.com>"]
 description = "Vibrato: viterbi-based accelerated tokenizer"
@@ -12,8 +12,8 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing"]
 
 [dependencies]
-bincode = "2.0.0-rc.1"  # MIT
-crawdad = "0.3.0"  # MIT or Apache-2.0
-csv-core = "0.1.10"  # Unlicense or MIT
-hashbrown = "0.12"  # MIT or Apache-2.0
-regex = "1"  # MIT or Apache-2.0
+bincode = "2.0.0-rc.1" # MIT
+crawdad = "0.3.0" # MIT or Apache-2.0
+csv-core = "0.1.10" # Unlicense or MIT
+hashbrown = "0.12" # MIT or Apache-2.0
+regex = "1" # MIT or Apache-2.0


### PR DESCRIPTION
The mapping formulas have changed slightly, but the dictionaries are still compatible.
So, this PR updates the version to 0.1.2, not 0.2.0.
(dependencies are automatically formatted with my toml formatter.)