### PR TITLE
Add unknown word edge as positive example

### DIFF
--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -237,7 +237,7 @@ ALPHA,0,0,0,動詞,*
 NUMERIC,0,0,0,数字";
 
     #[test]
-    fn test_optimal_unk_entry_1() {
+    fn test_compatible_unk_entry_1() {
         let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
         let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
 
@@ -252,7 +252,7 @@ NUMERIC,0,0,0,数字";
     }
 
     #[test]
-    fn test_optimal_unk_entry_2() {
+    fn test_compatible_unk_entry_2() {
         let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
         let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
 
@@ -267,7 +267,7 @@ NUMERIC,0,0,0,数字";
     }
 
     #[test]
-    fn test_optimal_unk_entry_undefined_1() {
+    fn test_compatible_unk_entry_undefined_1() {
         let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
         let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
 
@@ -279,7 +279,7 @@ NUMERIC,0,0,0,数字";
     }
 
     #[test]
-    fn test_optimal_unk_entry_undefined_2() {
+    fn test_compatible_unk_entry_undefined_2() {
         let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
         let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
 

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -145,7 +145,7 @@ impl UnkHandler {
 
         let groupable = sent.groupable(start_char);
 
-        if end_char - start_char <= cinfo.length().min(groupable) {
+        if cinfo.group() || end_char - start_char <= cinfo.length().min(groupable) {
             let start = self.offsets[usize::from_u32(cinfo.base_id())];
             let end = self.offsets[usize::from_u32(cinfo.base_id()) + 1];
             'a: for word_id in start..end {

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -132,7 +132,10 @@ impl UnkHandler {
         f
     }
 
-    pub fn optimal_unk_index(
+    /// Returns the earliest occurrence of a compatible unknown word for a given word.
+    ///
+    /// Returns `None` if no suitable entry exists.
+    pub fn compatible_unk_index(
         &self,
         sent: &Sentence,
         start_char: u16,
@@ -243,7 +246,7 @@ NUMERIC,0,0,0,数字";
         sent.compile(&prop).unwrap();
 
         let unk_index = unk
-            .optimal_unk_index(&sent, 2, 7, "名詞,一般,変数,バーヨンジューニ")
+            .compatible_unk_index(&sent, 2, 7, "名詞,一般,変数,バーヨンジューニ")
             .unwrap();
         assert_eq!(unk.word_feature(unk_index), "名詞,*,変数",);
     }
@@ -258,7 +261,7 @@ NUMERIC,0,0,0,数字";
         sent.compile(&prop).unwrap();
 
         let unk_index = unk
-            .optimal_unk_index(&sent, 2, 7, "動詞,一般,変数,バーヨンジューニ")
+            .compatible_unk_index(&sent, 2, 7, "動詞,一般,変数,バーヨンジューニ")
             .unwrap();
         assert_eq!(unk.word_feature(unk_index), "動詞,*",);
     }
@@ -272,7 +275,7 @@ NUMERIC,0,0,0,数字";
         sent.set_sentence("変数var42を書き換えます");
         sent.compile(&prop).unwrap();
 
-        assert!(unk.optimal_unk_index(&sent, 2, 7, "形容詞").is_none());
+        assert!(unk.compatible_unk_index(&sent, 2, 7, "形容詞").is_none());
     }
 
     #[test]
@@ -285,7 +288,7 @@ NUMERIC,0,0,0,数字";
         sent.compile(&prop).unwrap();
 
         assert!(unk
-            .optimal_unk_index(&sent, 5, 7, "名詞,一般,変数,バーヨンジューニ")
+            .compatible_unk_index(&sent, 5, 7, "名詞,一般,変数,バーヨンジューニ")
             .is_none());
     }
 }

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -248,7 +248,7 @@ NUMERIC,0,0,0,数字";
         let unk_index = unk
             .compatible_unk_index(&sent, 2, 7, "名詞,一般,変数,バーヨンジューニ")
             .unwrap();
-        assert_eq!(unk.word_feature(unk_index), "名詞,*,変数",);
+        assert_eq!(unk.word_feature(unk_index), "名詞,*,変数");
     }
 
     #[test]
@@ -263,7 +263,7 @@ NUMERIC,0,0,0,数字";
         let unk_index = unk
             .compatible_unk_index(&sent, 2, 7, "動詞,一般,変数,バーヨンジューニ")
             .unwrap();
-        assert_eq!(unk.word_feature(unk_index), "動詞,*",);
+        assert_eq!(unk.word_feature(unk_index), "動詞,*");
     }
 
     #[test]
@@ -278,7 +278,7 @@ NUMERIC,0,0,0,数字";
         let unk_index = unk
             .compatible_unk_index(&sent, 5, 7, "数字,一般,変数末尾,ヨンジューニ")
             .unwrap();
-        assert_eq!(unk.word_feature(unk_index), "数字",);
+        assert_eq!(unk.word_feature(unk_index), "数字");
     }
 
     #[test]

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -267,6 +267,21 @@ NUMERIC,0,0,0,数字";
     }
 
     #[test]
+    fn test_compatible_unk_entry_3() {
+        let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
+        let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
+
+        let mut sent = Sentence::new();
+        sent.set_sentence("変数var42を書き換えます");
+        sent.compile(&prop).unwrap();
+
+        let unk_index = unk
+            .compatible_unk_index(&sent, 5, 7, "数字,一般,変数末尾,ヨンジューニ")
+            .unwrap();
+        assert_eq!(unk.word_feature(unk_index), "数字",);
+    }
+
+    #[test]
     fn test_compatible_unk_entry_undefined_1() {
         let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
         let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -132,9 +132,9 @@ impl UnkHandler {
         f
     }
 
-    /// Returns the earliest occurrence of a compatible unknown word for a given word.
+    /// Returns the earliest occurrence of compatible unknown words for the given word.
     ///
-    /// Returns `None` if no suitable entry exists.
+    /// Returns `None` if no compatible entry exists.
     pub fn compatible_unk_index(
         &self,
         sent: &Sentence,

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -9,7 +9,7 @@ use crate::dictionary::mapper::ConnIdMapper;
 use crate::dictionary::word_idx::WordIdx;
 use crate::dictionary::LexType;
 use crate::sentence::Sentence;
-use crate::utils::FromU32;
+use crate::utils::{self, FromU32};
 
 use crate::common::MAX_SENTENCE_LENGTH;
 
@@ -132,6 +132,40 @@ impl UnkHandler {
         f
     }
 
+    pub fn optimal_unk_index(
+        &self,
+        sent: &Sentence,
+        start_char: u16,
+        end_char: u16,
+        feature: &str,
+    ) -> Option<WordIdx> {
+        let features = utils::parse_csv_row(feature);
+
+        let cinfo = sent.char_info(start_char);
+
+        let groupable = sent.groupable(start_char);
+
+        if end_char - start_char <= cinfo.length().min(groupable) {
+            let start = self.offsets[usize::from_u32(cinfo.base_id())];
+            let end = self.offsets[usize::from_u32(cinfo.base_id()) + 1];
+            'a: for word_id in start..end {
+                let e = &self.entries[word_id];
+                let unk_features = utils::parse_csv_row(&e.feature);
+                for (i, unk_feature) in unk_features.iter().enumerate() {
+                    if unk_feature != "*" && features.get(i).map_or(true, |f| unk_feature != f) {
+                        continue 'a;
+                    }
+                }
+                return Some(WordIdx::new(
+                    LexType::Unknown,
+                    u32::try_from(word_id).unwrap(),
+                ));
+            }
+        }
+
+        None
+    }
+
     #[inline(always)]
     pub fn word_param(&self, word_idx: WordIdx) -> WordParam {
         debug_assert_eq!(word_idx.lex_type, LexType::Unknown);
@@ -177,5 +211,81 @@ impl UnkHandler {
             }
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::dictionary::CharProperty;
+
+    const CHAR_DEF: &'static str = "\
+DEFAULT 0 1 0
+ALPHA   1 1 6
+NUMERIC 1 1 0
+0x0030..0x0039 NUMERIC
+0x0041..0x005A ALPHA NUMERIC
+0x0061..0x007A ALPHA NUMERIC";
+    const UNK_DEF: &'static str = "\
+DEFAULT,0,0,0,補助記号,*
+ALPHA,0,0,0,名詞,*,変数
+ALPHA,0,0,0,動詞,*
+NUMERIC,0,0,0,数字";
+
+    #[test]
+    fn test_optimal_unk_entry_1() {
+        let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
+        let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
+
+        let mut sent = Sentence::new();
+        sent.set_sentence("変数var42を書き換えます");
+        sent.compile(&prop).unwrap();
+
+        let unk_index = unk
+            .optimal_unk_index(&sent, 2, 7, "名詞,一般,変数,バーヨンジューニ")
+            .unwrap();
+        assert_eq!(unk.word_feature(unk_index), "名詞,*,変数",);
+    }
+
+    #[test]
+    fn test_optimal_unk_entry_2() {
+        let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
+        let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
+
+        let mut sent = Sentence::new();
+        sent.set_sentence("変数var42を書き換えます");
+        sent.compile(&prop).unwrap();
+
+        let unk_index = unk
+            .optimal_unk_index(&sent, 2, 7, "動詞,一般,変数,バーヨンジューニ")
+            .unwrap();
+        assert_eq!(unk.word_feature(unk_index), "動詞,*",);
+    }
+
+    #[test]
+    fn test_optimal_unk_entry_undefined_1() {
+        let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
+        let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
+
+        let mut sent = Sentence::new();
+        sent.set_sentence("変数var42を書き換えます");
+        sent.compile(&prop).unwrap();
+
+        assert!(unk.optimal_unk_index(&sent, 2, 7, "形容詞").is_none());
+    }
+
+    #[test]
+    fn test_optimal_unk_entry_undefined_2() {
+        let prop = CharProperty::from_reader(CHAR_DEF.as_bytes()).unwrap();
+        let unk = UnkHandler::from_reader(UNK_DEF.as_bytes(), &prop).unwrap();
+
+        let mut sent = Sentence::new();
+        sent.set_sentence("変数var42を書き換えます");
+        sent.compile(&prop).unwrap();
+
+        assert!(unk
+            .optimal_unk_index(&sent, 5, 7, "名詞,一般,変数,バーヨンジューニ")
+            .is_none());
     }
 }

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -293,11 +293,6 @@ impl Trainer {
                                     .unwrap()
                                 },
                                 |unk_index| {
-                                    eprintln!(
-                                        "adding positive unknown edge: {} {}",
-                                        token.surface(),
-                                        self.dict.unk_handler().word_feature(unk_index),
-                                    );
                                     u32::try_from(self.surfaces.len() + 1).unwrap()
                                         + unk_index.word_id
                                 },

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -266,6 +266,11 @@ impl Trainer {
         let unk_label_offset =
             NonZeroU32::new(u32::try_from(self.surfaces.len() + 1).unwrap()).unwrap();
 
+        // Add positive edges
+        // 1. If the word is found in the dictionary, add the edge as it is.
+        // 2. If the word is not found in the dictionary:
+        //   a) If a compatible unknown word is found, add the unknown word edge instead.
+        //   b) If there is no available word, add a virtual edge, which does not have any features.
         let mut edges = vec![];
         let mut pos = 0;
         for token in tokens {
@@ -304,7 +309,6 @@ impl Trainer {
 
         let mut lattice = Lattice::new(usize::from(input_len)).unwrap();
 
-        // Add positive edges
         for (pos, edge) in edges {
             lattice.add_edge(pos, edge).unwrap();
         }

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -299,7 +299,9 @@ impl Trainer {
                                 );
                                 virtual_edge_label
                             },
-                            |unk_index| unk_label_offset.checked_add(unk_index.word_id).unwrap(),
+                            |unk_index| {
+                                NonZeroU32::new(unk_label_offset.get() + unk_index.word_id).unwrap()
+                            },
                         )
                 });
             edges.push((pos, Edge::new(pos + len, label_id)));

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -95,7 +95,7 @@ pub struct Trainer {
 
     // Assume a dictionary word W is associated with id X and feature string F.
     // It maps F to a hash table that maps the first character of W to X.
-    label_id_map: HashMap<String, HashMap<char, u32>>,
+    label_id_map: HashMap<String, HashMap<char, NonZeroU32>>,
 
     regularization_cost: f64,
     max_iter: u64,
@@ -158,13 +158,13 @@ impl Trainer {
                 feature_str,
                 cate_id,
             );
-            provider.add_feature_set(feature_set)?;
+            let label_id = provider.add_feature_set(feature_set)?;
             label_id_map
                 .raw_entry_mut()
                 .from_key(feature_str)
                 .or_insert_with(|| (feature_str.to_string(), HashMap::new()))
                 .1
-                .insert(first_char, word_id);
+                .insert(first_char, label_id);
         }
         for word_id in 0..u32::try_from(config.dict.unk_handler().len()).unwrap() {
             let word_idx = WordIdx::new(LexType::Unknown, word_id);
@@ -261,6 +261,11 @@ impl Trainer {
         let input_chars = sentence.chars();
         let input_len = sentence.len_char();
 
+        let virtual_edge_label =
+            NonZeroU32::new(u32::try_from(self.provider.len()).unwrap()).unwrap();
+        let unk_label_offset =
+            NonZeroU32::new(u32::try_from(self.surfaces.len() + 1).unwrap()).unwrap();
+
         let mut edges = vec![];
         let mut pos = 0;
         for token in tokens {
@@ -270,40 +275,29 @@ impl Trainer {
                 .label_id_map
                 .get(token.feature())
                 .and_then(|hm| hm.get(&first_char))
-                .map_or_else(
-                    || {
-                        self.dict
-                            .unk_handler()
-                            .optimal_unk_index(
-                                sentence,
-                                u16::try_from(pos).unwrap(),
-                                u16::try_from(pos + len).unwrap(),
-                                token.feature(),
-                            )
-                            .map_or_else(
-                                || {
-                                    eprintln!(
-                                        "adding virtual edge: {} {}",
-                                        token.surface(),
-                                        token.feature()
-                                    );
-                                    u32::try_from(
-                                        self.surfaces.len() + self.dict.unk_handler().len() + 1,
-                                    )
-                                    .unwrap()
-                                },
-                                |unk_index| {
-                                    u32::try_from(self.surfaces.len() + 1).unwrap()
-                                        + unk_index.word_id
-                                },
-                            )
-                    },
-                    |label| *label + 1,
-                );
-            edges.push((
-                pos,
-                Edge::new(pos + len, NonZeroU32::new(label_id).unwrap()),
-            ));
+                .cloned()
+                .unwrap_or_else(|| {
+                    self.dict
+                        .unk_handler()
+                        .compatible_unk_index(
+                            sentence,
+                            u16::try_from(pos).unwrap(),
+                            u16::try_from(pos + len).unwrap(),
+                            token.feature(),
+                        )
+                        .map_or_else(
+                            || {
+                                eprintln!(
+                                    "adding virtual edge: {} {}",
+                                    token.surface(),
+                                    token.feature()
+                                );
+                                virtual_edge_label
+                            },
+                            |unk_index| unk_label_offset.checked_add(unk_index.word_id).unwrap(),
+                        )
+                });
+            edges.push((pos, Edge::new(pos + len, label_id)));
             pos += len;
         }
         assert_eq!(pos, usize::from(input_len));

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -327,6 +327,7 @@ impl Trainer {
                 let pos = usize::from(start_word);
                 let target = pos + usize::from(m.end_char);
                 let edge = Edge::new(target, label_id);
+                // Skips adding if the edge is already added as a positive edge.
                 if let Some(first_edge) = lattice.nodes()[pos].edges().first() {
                     if edge == *first_edge {
                         continue;
@@ -346,6 +347,7 @@ impl Trainer {
                     let pos = usize::from(start_word);
                     let target = usize::from(w.end_char());
                     let edge = Edge::new(target, label_id);
+                    // Skips adding if the edge is already added as a positive edge.
                     if let Some(first_edge) = lattice.nodes()[pos].edges().first() {
                         if edge == *first_edge {
                             return;


### PR DESCRIPTION
Currently, the trainer adds a virtual edge if the word in the corpus is not contained in the dictionary.
In this branch, if available, the trainer adds a compatible unknown word as a positive example.