### PR TITLE
Output result without flushing if stdout is not TTY

### DIFF
--- a/tokenize/Cargo.toml
+++ b/tokenize/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 default = []
 
 [dependencies]
+atty = "0.2"  # MIT
 vibrato = { path = "../vibrato" }
 bincode = "2.0.0-rc.1"  # MIT
 clap = { version = "3.1", features = ["derive"] }  # MIT or Apache-2.0


### PR DESCRIPTION
This PR changes the `tokenize` command to output results without flushing if the standard out is not a TTY.

## Speed comparison (excluding model loading)
```
cargo run --release -p tokenize -- -i my.dic < input.txt > /dev/null
```
main branch: 754 [ms]
this branch: 548 [ms]

----

```
cargo run --release -p tokenize -- -i my.dic < input.txt > ./result.txt
```
main branch: 1261 [ms]
this branch: 649 [ms]