### PR TITLE
Bi-gram cost details

### DIFF
--- a/dictgen/src/main.rs
+++ b/dictgen/src/main.rs
@@ -32,9 +32,10 @@ struct Args {
     #[clap(long)]
     user_lexicon_out: Option<PathBuf>,
 
-    /// Outputs a list of features associated with each left connection ID.
+    /// Outputs a list of features associated with each connection ID and a list of bi-gram
+    /// weights.
     ///
-    /// The file name is suffixed with `.left` and `.right`.
+    /// The file name is suffixed with `.left`, `.right`, and `.weight`.
     #[clap(long)]
     conn_id_info_out: Option<PathBuf>,
 }

--- a/dictgen/src/main.rs
+++ b/dictgen/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let left_wtr = File::create(left_path)?;
         let right_wtr = File::create(right_path)?;
         let bigram_weight_wtr = File::create(bigram_weight_path)?;
-        model.write_used_features(left_wtr, right_wtr, bigram_weight_wtr)?;
+        model.write_bigram_details(left_wtr, right_wtr, bigram_weight_wtr)?;
     }
 
     Ok(())

--- a/dictgen/src/main.rs
+++ b/dictgen/src/main.rs
@@ -33,9 +33,9 @@ struct Args {
     user_lexicon_out: Option<PathBuf>,
 
     /// Outputs a list of features associated with each connection ID and a list of bi-gram
-    /// weights.
+    /// costs.
     ///
-    /// The file name is suffixed with `.left`, `.right`, and `.weight`.
+    /// The file names are suffixed with `.left`, `.right`, and `.cost`.
     #[clap(long)]
     conn_id_info_out: Option<PathBuf>,
 }

--- a/dictgen/src/main.rs
+++ b/dictgen/src/main.rs
@@ -70,12 +70,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(path) = args.conn_id_info_out {
         let ext = path.as_os_str().to_os_string();
         let mut left_path = ext.clone();
-        let mut right_path = ext;
+        let mut right_path = ext.clone();
+        let mut bigram_weight_path = ext;
         left_path.push(".left");
         right_path.push(".right");
+        bigram_weight_path.push(".weight");
         let left_wtr = File::create(left_path)?;
         let right_wtr = File::create(right_path)?;
-        model.write_used_features(left_wtr, right_wtr)?;
+        let bigram_weight_wtr = File::create(bigram_weight_path)?;
+        model.write_used_features(left_wtr, right_wtr, bigram_weight_wtr)?;
     }
 
     Ok(())

--- a/dictgen/src/main.rs
+++ b/dictgen/src/main.rs
@@ -72,14 +72,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let ext = path.as_os_str().to_os_string();
         let mut left_path = ext.clone();
         let mut right_path = ext.clone();
-        let mut bigram_weight_path = ext;
+        let mut cost_path = ext;
         left_path.push(".left");
         right_path.push(".right");
-        bigram_weight_path.push(".weight");
+        cost_path.push(".cost");
         let left_wtr = File::create(left_path)?;
         let right_wtr = File::create(right_path)?;
-        let bigram_weight_wtr = File::create(bigram_weight_path)?;
-        model.write_bigram_details(left_wtr, right_wtr, bigram_weight_wtr)?;
+        let cost_wtr = File::create(cost_path)?;
+        model.write_bigram_details(left_wtr, right_wtr, cost_wtr)?;
     }
 
     Ok(())

--- a/vibrato/src/trainer/model.rs
+++ b/vibrato/src/trainer/model.rs
@@ -101,7 +101,7 @@ impl Model {
     ///
     /// - merging weights fails, or
     /// - the writing fails.
-    pub fn write_used_features<L, R, B>(
+    pub fn write_bigram_details<L, R, B>(
         &mut self,
         left_wtr: L,
         right_wtr: R,

--- a/vibrato/src/trainer/model.rs
+++ b/vibrato/src/trainer/model.rs
@@ -120,7 +120,7 @@ impl Model {
         }
         let feature_list = &merged_model.left_conn_to_right_feats;
         let mut left_wtr = BufWriter::new(left_wtr);
-        for (conn_id, feat_ids) in feature_list[..feature_list.len() - 1].iter().enumerate() {
+        for (conn_id, feat_ids) in feature_list[..feature_list.len()].iter().enumerate() {
             write!(&mut left_wtr, "{}", conn_id + 1)?;
             for (i, feat_id) in feat_ids.iter().enumerate() {
                 if let Some(feat_id) = feat_id {
@@ -138,7 +138,7 @@ impl Model {
         }
         let feature_list = &merged_model.right_conn_to_left_feats;
         let mut right_wtr = BufWriter::new(right_wtr);
-        for (conn_id, feat_ids) in feature_list[..feature_list.len() - 1].iter().enumerate() {
+        for (conn_id, feat_ids) in feature_list[..feature_list.len()].iter().enumerate() {
             write!(&mut right_wtr, "{}", conn_id + 1)?;
             for (i, feat_id) in feat_ids.iter().enumerate() {
                 if let Some(feat_id) = feat_id {
@@ -199,7 +199,7 @@ impl Model {
         }
         for hm in &merged_model.matrix {
             for &w in hm.values() {
-                weight_abs_max = weight_abs_max.max(w);
+                weight_abs_max = weight_abs_max.max(w.abs());
             }
         }
         let weight_scale_factor = f64::from(i16::MAX) / weight_abs_max;

--- a/vibrato/src/trainer/model.rs
+++ b/vibrato/src/trainer/model.rs
@@ -92,20 +92,21 @@ impl Model {
     ///
     /// # Arguments
     ///
-    /// * `left_wtr` - Write sink targetting `left.def`.
-    /// * `right_wtr` - Write sink targetting `right.def`.
+    /// * `left_wtr` - Write sink targetting the `.left` file.
+    /// * `right_wtr` - Write sink targetting the `.right` file.
+    /// * `cost_wtr` - Write sink targetting the `.cost` file.
     ///
     /// # Errors
     ///
     /// [`VibratoError`](crate::errors::VibratoError) is returned when:
     ///
-    /// - merging weights fails, or
+    /// - merging costs fails, or
     /// - the writing fails.
     pub fn write_bigram_details<L, R, B>(
         &mut self,
         left_wtr: L,
         right_wtr: R,
-        bigram_weight_wtr: B,
+        cost_wtr: B,
     ) -> Result<()>
     where
         L: Write,
@@ -177,7 +178,7 @@ impl Model {
             writeln!(&mut right_wtr)?;
         }
 
-        let mut bigram_weight_wtr = BufWriter::new(bigram_weight_wtr);
+        let mut cost_wtr = BufWriter::new(cost_wtr);
         for (left_feat_id, hm) in self
             .data
             .raw_model
@@ -191,10 +192,10 @@ impl Model {
             for (right_feat_id, widx) in hm {
                 let right_feat_str = right_features.get(right_feat_id).map_or("", |x| x.as_str());
                 let w = self.data.raw_model.weights()[usize::from_u32(*widx)];
-                let w = (-w * weight_scale_factor) as i32;
+                let cost = (-w * weight_scale_factor) as i32;
                 writeln!(
-                    &mut bigram_weight_wtr,
-                    "{left_feat_str}/{right_feat_str}\t{w}"
+                    &mut cost_wtr,
+                    "{left_feat_str}/{right_feat_str}\t{cost}"
                 )?;
             }
         }
@@ -215,7 +216,7 @@ impl Model {
     ///
     /// [`VibratoError`](crate::errors::VibratoError) is returned when:
     ///
-    /// - merging weights fails, or
+    /// - merging costs fails, or
     /// - the writing fails.
     pub fn write_dictionary<L, C, U, S>(
         &mut self,

--- a/vibrato/src/trainer/model.rs
+++ b/vibrato/src/trainer/model.rs
@@ -102,16 +102,16 @@ impl Model {
     ///
     /// - merging costs fails, or
     /// - the writing fails.
-    pub fn write_bigram_details<L, R, B>(
+    pub fn write_bigram_details<L, R, C>(
         &mut self,
         left_wtr: L,
         right_wtr: R,
-        cost_wtr: B,
+        cost_wtr: C,
     ) -> Result<()>
     where
         L: Write,
         R: Write,
-        B: Write,
+        C: Write,
     {
         if self.merged_model.is_none() {
             self.merged_model = Some(self.data.raw_model.merge()?);
@@ -193,10 +193,7 @@ impl Model {
                 let right_feat_str = right_features.get(right_feat_id).map_or("", |x| x.as_str());
                 let w = self.data.raw_model.weights()[usize::from_u32(*widx)];
                 let cost = (-w * weight_scale_factor) as i32;
-                writeln!(
-                    &mut cost_wtr,
-                    "{left_feat_str}/{right_feat_str}\t{cost}"
-                )?;
+                writeln!(&mut cost_wtr, "{left_feat_str}/{right_feat_str}\t{cost}")?;
             }
         }
         Ok(())


### PR DESCRIPTION
This PR modifies the `write_used_features()` function to output the weights given to the bi-gram features and renames `write_used_features()` to `write_bigram_details()`.

Example generated from the test corpus:
```
B3:名詞,普通名詞,一般/名詞,普通名詞,一般	15960
B3:名詞,普通名詞,一般/名詞,普通名詞,サ変可能	-520
B4:名詞,普通名詞,一般,*/名詞,普通名詞,サ変可能,*	-520
B4:名詞,普通名詞,一般,*/名詞,普通名詞,一般,*	15960
B2:名詞,固有名詞/名詞,固有名詞	3117
B3:名詞,固有名詞,地名/名詞,普通名詞,サ変可能	520
B3:名詞,固有名詞,地名/名詞,固有名詞,地名	3117
B3:名詞,固有名詞,地名/名詞,普通名詞,一般	-3117
B4:名詞,固有名詞,地名,一般/名詞,普通名詞,一般,*	-3117
B4:名詞,固有名詞,地名,一般/名詞,普通名詞,サ変可能,*	520
B4:名詞,固有名詞,地名,一般/名詞,固有名詞,地名,一般	3117
B1:接尾辞/名詞	8191
B2:接尾辞,名詞的/名詞,普通名詞	8191
B3:接尾辞,名詞的,一般/名詞,普通名詞,一般	8191
B4:接尾辞,名詞的,一般,*/名詞,普通名詞,一般,*	8191
```