### PR TITLE
Fix the version of bincode_derive = 2.0.0-rc.1

### DIFF
--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -15,8 +15,7 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing"]
 
 [dependencies]
-bincode = "=2.0.0-rc.1" # MIT
-bincode_derive = "=2.0.0-rc.1" # MIT
+bincode = { version = "=2.0.0-rc.1", features = ["derive"] } # MIT
 crawdad = "0.3.0" # MIT or Apache-2.0
 csv-core = "0.1.10" # Unlicense or MIT
 hashbrown = "0.12" # MIT or Apache-2.0

--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -15,7 +15,8 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing"]
 
 [dependencies]
-bincode = { version = "=2.0.0-rc.1", features = ["derive"] } # MIT
+bincode = "=2.0.0-rc.1" # MIT
+bincode_derive = "=2.0.0-rc.1" # MIT
 crawdad = "0.3.0" # MIT or Apache-2.0
 csv-core = "0.1.10" # Unlicense or MIT
 hashbrown = "0.12" # MIT or Apache-2.0

--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing"]
 
 [dependencies]
-bincode = "2.0.0-rc.1" # MIT
-bincode_derive = "2.0.0-rc.1" # MIT
+bincode = "=2.0.0-rc.1" # MIT
+bincode_derive = "=2.0.0-rc.1" # MIT
 crawdad = "0.3.0" # MIT or Apache-2.0
 csv-core = "0.1.10" # Unlicense or MIT
 hashbrown = "0.12" # MIT or Apache-2.0

--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["text-processing"]
 
 [dependencies]
 bincode = "2.0.0-rc.1" # MIT
+bincode_derive = "2.0.0-rc.1" # MIT
 crawdad = "0.3.0" # MIT or Apache-2.0
 csv-core = "0.1.10" # Unlicense or MIT
 hashbrown = "0.12" # MIT or Apache-2.0


### PR DESCRIPTION
Because of last night's update of bincode (cf. https://github.com/bincode-org/bincode/releases/tag/v2.0.0-rc.2), `cargo check` seems to fail, as follows https://github.com/daac-tools/vibrato/actions/runs/3186512908/jobs/5197179103.

This PR fixes the error by specifying the version of bincode_derive to 2.0.0-rc.1.


