### PR TITLE
Separate advanced documentation from the top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ The detailed experimental settings and other results are available on [Wiki](htt
 
 Vibrato supports options for outputting tokenized results identical to MeCab, such as ignoring whitespace.
 
+### Training parameters
+
+Vibrato also supports training parameters (or costs) in dictionaries from your corpus.
+The detailed description can be found [here](./docs/train.md).
+
 ## Basic usage
 
 This software is implemented in Rust.
@@ -94,7 +99,9 @@ $ echo '本とカレーの街神保町へようこそ。' | cargo run --release 
 本 と カレー の 街 神保 町 へ ようこそ 。
 ```
 
-## MeCab-compatible options
+## Tokenization options
+
+### MeCab-compatible options
 
 Vibrato is a reimplementation of the MeCab algorithm,
 but with the default settings it can produce different tokens from MeCab.
@@ -134,12 +141,12 @@ EOS
 `-S` indicates if spaces are ignored.
 `-M` indicates the maximum grouping length for unknown words.
 
-### Notes
+#### Notes
 
 There are corner cases where tokenization results in different outcomes due to cost tiebreakers.
 However, this would be not an essential problem.
 
-## User dictionary
+### User dictionary
 
 You can use your user dictionary along with the system dictionary.
 The user dictionary must be in the CSV format.
@@ -172,16 +179,9 @@ $ echo '本とカレーの街神保町へようこそ。' | cargo run --release 
 EOS
 ```
 
-## Benchmark
+## More advanced usages
 
-You can measure the tokenization speed for sentences in `test.txt`.
-
-If you can guarantee that `system.dic` is exported from this library,
-you can specify `--features=unchecked` for faster tokenization.
-
-```
-$ cargo run --release -p benchmark --features=unchecked -- -i resources_ipadic-mecab-2_7_0/system.dic < test.txt
-```
+The directory [docs](./docs/) provides descriptions of more advanced usages such as training or benchmarking.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Vibrato supports options for outputting tokenized results identical to MeCab, su
 
 ### Training parameters
 
-Vibrato also supports training parameters (or costs) in dictionaries from your corpus.
+Vibrato also supports training parameters (or costs) in dictionaries from your corpora.
 The detailed description can be found [here](./docs/train.md).
 
 ## Basic usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# vibrato/docs
+
+Here provides several documents for advanced usages.
+
+- [`prepare.md`](./prepare.md) describes how to compile Vibrato's system dictionaries from language resources.
+- [`train.md`](./train.md) describes how to train dictionaries from your corpus.
+- [`small-dic.md`](./small-dic.md) describes how to generate smaller system dictionaries.
+- [`benchmark`](./benchmark.md) describes how to benchmark the tokenization speed of Vibrato.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,10 +1,15 @@
 # Benchmarking
 
-You can measure the tokenization speed for sentences in `test.txt`.
+You can measure the tokenization speed using a system dictionary `system.dic`
+and sentences in `test.txt` with the following command.
+
+```
+$ cargo run --release -p benchmark -- -i system.dic < test.txt
+```
 
 If you can guarantee that `system.dic` is exported from this library,
 you can specify `--features=unchecked` for faster tokenization.
 
 ```
-$ cargo run --release -p benchmark --features=unchecked -- -i resources_ipadic-mecab-2_7_0/system.dic < test.txt
+$ cargo run --release -p benchmark --features=unchecked -- -i system.dic < test.txt
 ```

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,10 @@
+# Benchmarking
+
+You can measure the tokenization speed for sentences in `test.txt`.
+
+If you can guarantee that `system.dic` is exported from this library,
+you can specify `--features=unchecked` for faster tokenization.
+
+```
+$ cargo run --release -p benchmark --features=unchecked -- -i resources_ipadic-mecab-2_7_0/system.dic < test.txt
+```

--- a/docs/prepare.md
+++ b/docs/prepare.md
@@ -1,6 +1,6 @@
 # Preparation of Vibrato's dictionaries
 
-This documentation describes steps to compile Vibrato's system dictionaries.
+This document describes steps to compile Vibrato's system dictionaries.
 
 The following description assumes you are at the root directory of this repository.
 

--- a/docs/prepare.md
+++ b/docs/prepare.md
@@ -1,6 +1,8 @@
-# vibrato/prepare
+# Preparation of Vibrato's dictionaries
 
-This workspace provides several tools to compile Vibrato's dictionaries.
+This documentation describes steps to compile Vibrato's system dictionaries.
+
+The following description assumes you are at the root directory of this repository.
 
 ## 1. Compiling system dictionary
 
@@ -18,7 +20,7 @@ To compile the system dictionary from the resource,
 run the following command.
 
 ```
-$ cargo run --release --bin system -- \
+$ cargo run --release -p prepare --bin system -- \
     -l unidic-mecab-2.1.2_src/lex.csv \
     -m unidic-mecab-2.1.2_src/matrix.def \
     -u unidic-mecab-2.1.2_src/unk.def \
@@ -39,7 +41,7 @@ To produce the reordered mapping from sentences in `train.txt`,
 run the following command.
 
 ```
-$ cargo run --release --bin reorder -- -i system.dic -o reordered < train.txt
+$ cargo run --release -p prepare --bin reorder -- -i system.dic -o reordered < train.txt
 ```
 
 The two files, `reordered.lmap` and `reordered.rmap`, will be produced.
@@ -50,8 +52,8 @@ To edit a system dictionary with the reordered mapping,
 run the following command.
 
 ```
-$ cargo run --release --bin map -- -i system.dic -m reordered -o system.mapped.dic
+$ cargo run --release -p prepare --bin map -- -i system.dic -m reordered -o system.mapped.dic
 ```
 
 When the matrix data is large,
-`system.mapped.dic` will provide faster tokenization then `system.dic`.
+`system.mapped.dic` will provide faster tokenization than `system.dic`.

--- a/docs/small-dic.md
+++ b/docs/small-dic.md
@@ -8,7 +8,7 @@ The following description assumes you are at the root directory of this reposito
 
 ## 1. Training
 
-To generate a smaller dictionary, you need to prepare a trained model file from your corpus following the step 1 in [this document](./train.md).
+To generate a smaller dictionary, you need to prepare a trained model file from your corpus following the step 1 in [this document](./train.md#1-training).
 
 ## 2. Generating dictionary files
 

--- a/docs/small-dic.md
+++ b/docs/small-dic.md
@@ -1,0 +1,48 @@
+# Generating smaller dictionaries
+
+Vibrato provides an option to generate smaller a dictionary that stores connection costs in compressed space,
+while sacrificing tokenization speed.
+This documentation describes the generation steps. 
+
+The following description assumes you are at the root directory of this repository.
+
+## 1. Training
+
+To generate a smaller dictionary, you need to prepare a trained model file from your corpus following the step 1 in [this document](./train.md).
+
+## 2. Generating dictionary files
+
+To generate a compact dictionary, give `--conn-id-info-out` option to the `dictgen` command as follows:
+```
+$ cargo run --release -p dictgen -- \
+    -i ./modeldata.zst \
+    -l ./mydict/lex.csv \
+    -u ./mydict/unk.def \
+    -m ./mydict/matrix.def \
+    --conn-id-info-out ./mydict/bigram
+```
+
+This command generates three files: `./mydict/bigram.left`, `./mydict/bigram.right`, and `./mydict/bigram.cost`.
+
+## 3. Compiling system dictionary
+
+Run the `prepare/system` command with the `--bigram-*` options instead of the `-m` option as follows:
+```
+$ cargo run --release -p prepare --bin system -- \
+    -l ./mydict/lex.csv \
+    -u ./mydict/unk.def \
+    -c ./mydict/char.def \
+    --bigram-left-in ./mydict/bigram.left \
+    --bigram-right-in ./mydict/bigram.right \
+    --bigram-cost-in ./mydict/bigram.cost \
+    -o system-compact.dic
+```
+
+The compiled dictionary `system-compact.dic` can be used in place of the system dictionary `system.dic` described above.
+
+## SIMD acceleration
+
+Compiling the `tokenize` command with the `target-feature=+avx2` option enables a SIMD acceleration (if your machine supports it) and will reduce the analyzing time:
+```
+$ RUSTFLAGS='-C target-feature=+avx2' cargo build --release -p tokenize
+```

--- a/docs/small-dic.md
+++ b/docs/small-dic.md
@@ -2,7 +2,7 @@
 
 Vibrato provides an option to generate smaller a dictionary that stores connection costs in compressed space,
 while sacrificing tokenization speed.
-This documentation describes the generation steps. 
+This document describes the generation steps. 
 
 The following description assumes you are at the root directory of this repository.
 

--- a/docs/train.md
+++ b/docs/train.md
@@ -1,0 +1,83 @@
+# Training dictionaries
+
+This documentation describes steps to train dictionaries using Vibrato.
+
+The following description assumes you are at the root directory of this repository.
+
+## 1. Training
+
+To train a dictionary, you must prepare at least the following six files.
+
+* `corpus.txt`: Corpus file to be trained. The format is the same as the output of the `tokenize` command of Vibrato.
+                The contents of the feature columns must match exactly with the columns of the lexicon file.
+                If it differs even slightly, it is considered an unknown word.
+* `train_lex.csv`: Lexicon file to be weighted. All connection IDs and weights must be set to 0.
+* `train_unk.def`: Unknown word file to be weighted. All connection IDs and weights must be set to 0.
+* `char.def`: Character definition file.
+* `rewrite.def`: Rewrite rule definition file.
+* `feature.def`: Feature definition file.
+
+The file formats follow those in MeCab (see the [official document](https://taku910.github.io/mecab/learn.html)).
+You can also find an example dataset [here](../vibrato/src/tests/resources).
+
+Execute the following command to start the training process (Replace file names with the actual ones):
+```
+$ cargo run --release -p train -- \
+    -t ./dataset/corpus.txt \
+    -l ./dataset/train_lex.csv \
+    -u ./dataset/train_unk.def \
+    -c ./dataset/char.def \
+    -f ./dataset/feature.def \
+    -r ./dataset/rewrite.def \
+    -o ./modeldata.zst
+```
+
+The training command supports multi-threading and changing some parameters.
+See the `--help` message for more details.
+
+When training is complete, the model is output to `./modeldata.zst`.
+
+## 2. Generating dictionary files
+
+Run the following commands to generate a set of dictionary files from the model:
+
+```
+$ mkdir mydict # Prepare the output directory
+$ cargo run --release -p dictgen -- \
+    -i ./modeldata.zst \
+    -l ./mydict/lex.csv \
+    -u ./mydict/unk.def \
+    -m ./mydict/matrix.def
+```
+
+Optionally, you can specify a user-defined dictionary to the `dictgen` command to automatically give connection IDs and weights.
+See the `--help` message for more details.
+
+After copying `dataset/char.def` under `mydict`, you can compile your system dictionary
+following the [documentation](./prepare.md).
+
+## 3. Accuracy evaluation
+
+To split the input corpus randomly and output train/validation/test files, run the following command:
+
+```
+$ cargo run --release -p evaluate --bin split -- \
+    -i ./dataset/corpus.txt \
+    -t ./dataset/train.txt \
+    -v ./dataset/valid.txt \
+    -e ./dataset/test.txt
+```
+
+By default, 80% of the data is split into a training set, 10% into a validation set, and 10% into a test set.
+
+To evaluate the accuracy, run the following command:
+
+```
+$ cargo run --release -p evaluate -- \
+    -i ./system.dic \
+    -t ./dataset/valid.txt \
+    --feature-indices 0,1,2,3,9
+```
+
+where `--feature-indices` is an option to specify features' indices to determine correctness.
+In this example, the 0th, 1st, 2nd, 3rd, and 9th features are considered.

--- a/docs/train.md
+++ b/docs/train.md
@@ -1,6 +1,6 @@
 # Training dictionaries
 
-This documentation describes steps to train dictionaries using Vibrato.
+This document describes steps to train dictionaries using Vibrato.
 
 The following description assumes you are at the root directory of this repository.
 


### PR DESCRIPTION
Following https://github.com/daac-tools/vibrato/issues/68, this PR keeps only descriptions of tokenization in the top-level readme and places more advanced descriptions in the `docs` directory.