### PR TITLE
Use usize to support long input

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         for _ in 0..RUNS {
             t.start();
             for line in &lines {
-                worker.reset_sentence(line).unwrap();
+                worker.reset_sentence(line);
                 worker.tokenize();
                 n_words += worker.num_tokens();
             }

--- a/evaluate/src/main.rs
+++ b/evaluate/src/main.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             start += len;
         }
-        worker.reset_sentence(input_str)?;
+        worker.reset_sentence(input_str);
         worker.tokenize();
         for token in worker.token_iter() {
             let features = parse_csv_row(token.feature());

--- a/prepare/src/reorder.rs
+++ b/prepare/src/reorder.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
-        worker.reset_sentence(line)?;
+        worker.reset_sentence(line);
         worker.tokenize();
         worker.update_connid_counts();
     }

--- a/tokenize/src/main.rs
+++ b/tokenize/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
-        worker.reset_sentence(line)?;
+        worker.reset_sentence(line);
         worker.tokenize();
         match args.output_mode {
             OutputMode::Mecab => {

--- a/vibrato/README.md
+++ b/vibrato/README.md
@@ -16,7 +16,7 @@ let dict = Dictionary::read(BufReader::new(file)).unwrap();
 let tokenizer = vibrato::Tokenizer::new(dict);
 let mut worker = tokenizer.new_worker();
 
-worker.reset_sentence("京都東京都").unwrap();
+worker.reset_sentence("京都東京都");
 worker.tokenize();
 assert_eq!(worker.num_tokens(), 2);
 

--- a/vibrato/src/common.rs
+++ b/vibrato/src/common.rs
@@ -13,7 +13,7 @@ pub const fn bincode_config() -> config::Configuration<LittleEndian, Fixint> {
 ///
 /// Note that the value must be represented with u16 so that
 /// an (exclusive) end position can be represented in 16 bits.
-pub const MAX_SENTENCE_LENGTH: u16 = 0xFFFF;
+pub const MAX_SENTENCE_LENGTH: usize = usize::MAX;
 
 /// The fixed connection id of BOS/EOS.
 pub const BOS_EOS_CONNECTION_ID: u16 = 0;

--- a/vibrato/src/dictionary/lexicon.rs
+++ b/vibrato/src/dictionary/lexicon.rs
@@ -99,12 +99,12 @@ impl Lexicon {
 pub struct LexMatch {
     pub word_idx: WordIdx,
     pub word_param: WordParam,
-    pub end_char: u16,
+    pub end_char: usize,
 }
 
 impl LexMatch {
     #[inline(always)]
-    pub const fn new(word_idx: WordIdx, word_param: WordParam, end_char: u16) -> Self {
+    pub const fn new(word_idx: WordIdx, word_param: WordParam, end_char: usize) -> Self {
         Self {
             word_idx,
             word_param,

--- a/vibrato/src/dictionary/lexicon/map.rs
+++ b/vibrato/src/dictionary/lexicon/map.rs
@@ -33,7 +33,7 @@ impl WordMap {
     pub fn common_prefix_iterator<'a>(
         &'a self,
         input: &'a [char],
-    ) -> impl Iterator<Item = (u32, u16)> + 'a {
+    ) -> impl Iterator<Item = (u32, usize)> + 'a {
         self.trie.common_prefix_iterator(input).flat_map(move |e| {
             self.postings
                 .ids(usize::from_u32(e.value))
@@ -45,7 +45,7 @@ impl WordMap {
     pub unsafe fn common_prefix_iterator_unchecked<'a>(
         &'a self,
         input: &'a [char],
-    ) -> impl Iterator<Item = (u32, u16)> + 'a {
+    ) -> impl Iterator<Item = (u32, usize)> + 'a {
         self.trie.common_prefix_iterator(input).flat_map(move |e| {
             self.postings
                 .ids_unchecked(usize::from_u32(e.value))

--- a/vibrato/src/dictionary/lexicon/map/trie.rs
+++ b/vibrato/src/dictionary/lexicon/map/trie.rs
@@ -54,7 +54,6 @@ impl Trie {
         self.da
             .common_prefix_search(input.iter().cloned())
             .map(move |(value, end_char)| {
-                // Safety: input.len() is no more than 0xFFFF.
                 TrieMatch::new(value, end_char)
             })
     }

--- a/vibrato/src/dictionary/lexicon/map/trie.rs
+++ b/vibrato/src/dictionary/lexicon/map/trie.rs
@@ -55,7 +55,7 @@ impl Trie {
             .common_prefix_search(input.iter().cloned())
             .map(move |(value, end_char)| {
                 // Safety: input.len() is no more than 0xFFFF.
-                TrieMatch::new(value, unsafe { u16::try_from(end_char).unwrap_unchecked() })
+                TrieMatch::new(value, end_char)
             })
     }
 }
@@ -63,12 +63,12 @@ impl Trie {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TrieMatch {
     pub value: u32,
-    pub end_char: u16,
+    pub end_char: usize,
 }
 
 impl TrieMatch {
     #[inline(always)]
-    pub const fn new(value: u32, end_char: u16) -> Self {
+    pub const fn new(value: u32, end_char: usize) -> Self {
         Self { value, end_char }
     }
 }

--- a/vibrato/src/dictionary/lexicon/map/trie.rs
+++ b/vibrato/src/dictionary/lexicon/map/trie.rs
@@ -53,9 +53,7 @@ impl Trie {
         debug_assert!(input.len() <= 0xFFFF);
         self.da
             .common_prefix_search(input.iter().cloned())
-            .map(move |(value, end_char)| {
-                TrieMatch::new(value, end_char)
-            })
+            .map(move |(value, end_char)| TrieMatch::new(value, end_char))
     }
 }
 

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -246,7 +246,7 @@ NUMERIC,0,0,0,数字";
 
         let mut sent = Sentence::new();
         sent.set_sentence("変数var42を書き換えます");
-        sent.compile(&prop).unwrap();
+        sent.compile(&prop);
 
         let unk_index = unk
             .compatible_unk_index(&sent, 2, 7, "名詞,一般,変数,バーヨンジューニ")
@@ -261,7 +261,7 @@ NUMERIC,0,0,0,数字";
 
         let mut sent = Sentence::new();
         sent.set_sentence("変数var42を書き換えます");
-        sent.compile(&prop).unwrap();
+        sent.compile(&prop);
 
         let unk_index = unk
             .compatible_unk_index(&sent, 2, 7, "動詞,一般,変数,バーヨンジューニ")
@@ -276,7 +276,7 @@ NUMERIC,0,0,0,数字";
 
         let mut sent = Sentence::new();
         sent.set_sentence("変数var42を書き換えます");
-        sent.compile(&prop).unwrap();
+        sent.compile(&prop);
 
         let unk_index = unk
             .compatible_unk_index(&sent, 5, 7, "数字,一般,変数末尾,ヨンジューニ")
@@ -291,7 +291,7 @@ NUMERIC,0,0,0,数字";
 
         let mut sent = Sentence::new();
         sent.set_sentence("変数var42を書き換えます");
-        sent.compile(&prop).unwrap();
+        sent.compile(&prop);
 
         assert!(unk.compatible_unk_index(&sent, 2, 7, "形容詞").is_none());
     }
@@ -303,7 +303,7 @@ NUMERIC,0,0,0,数字";
 
         let mut sent = Sentence::new();
         sent.set_sentence("変数var42を書き換えます");
-        sent.compile(&prop).unwrap();
+        sent.compile(&prop);
 
         assert!(unk
             .compatible_unk_index(&sent, 5, 7, "名詞,一般,変数,バーヨンジューニ")

--- a/vibrato/src/dictionary/unknown.rs
+++ b/vibrato/src/dictionary/unknown.rs
@@ -24,8 +24,8 @@ pub struct UnkEntry {
 
 #[derive(Default, Debug, Clone)]
 pub struct UnkWord {
-    start_char: u16,
-    end_char: u16,
+    start_char: usize,
+    end_char: usize,
     left_id: u16,
     right_id: u16,
     word_cost: i16,
@@ -34,12 +34,12 @@ pub struct UnkWord {
 
 impl UnkWord {
     #[inline(always)]
-    pub const fn start_char(&self) -> u16 {
+    pub const fn start_char(&self) -> usize {
         self.start_char
     }
 
     #[inline(always)]
-    pub const fn end_char(&self) -> u16 {
+    pub const fn end_char(&self) -> usize {
         self.end_char
     }
 
@@ -65,9 +65,9 @@ impl UnkHandler {
     pub fn gen_unk_words<F>(
         &self,
         sent: &Sentence,
-        start_char: u16,
+        start_char: usize,
         mut has_matched: bool,
-        max_grouping_len: Option<u16>,
+        max_grouping_len: Option<usize>,
         mut f: F,
     ) where
         F: FnMut(UnkWord),
@@ -93,7 +93,7 @@ impl UnkHandler {
             }
         }
 
-        for i in 1..=cinfo.length().min(groupable) {
+        for i in 1..=usize::from(cinfo.length()).min(groupable) {
             if grouped && i == groupable {
                 continue;
             }
@@ -112,7 +112,7 @@ impl UnkHandler {
     }
 
     #[inline(always)]
-    fn scan_entries<F>(&self, start_char: u16, end_char: u16, cinfo: CharInfo, mut f: F) -> F
+    fn scan_entries<F>(&self, start_char: usize, end_char: usize, cinfo: CharInfo, mut f: F) -> F
     where
         F: FnMut(UnkWord),
     {
@@ -138,8 +138,8 @@ impl UnkHandler {
     pub fn compatible_unk_index(
         &self,
         sent: &Sentence,
-        start_char: u16,
-        end_char: u16,
+        start_char: usize,
+        end_char: usize,
         feature: &str,
     ) -> Option<WordIdx> {
         let features = utils::parse_csv_row(feature);
@@ -148,7 +148,7 @@ impl UnkHandler {
 
         let groupable = sent.groupable(start_char);
 
-        if cinfo.group() || end_char - start_char <= cinfo.length().min(groupable) {
+        if cinfo.group() || end_char - start_char <= usize::from(cinfo.length()).min(groupable) {
             let start = self.offsets[usize::from_u32(cinfo.base_id())];
             let end = self.offsets[usize::from_u32(cinfo.base_id()) + 1];
             'a: for word_id in start..end {

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -25,7 +25,7 @@
 //! let tokenizer = vibrato::Tokenizer::new(dict);
 //! let mut worker = tokenizer.new_worker();
 //!
-//! worker.reset_sentence("京都東京都").unwrap();
+//! worker.reset_sentence("京都東京都");
 //! worker.tokenize();
 //! assert_eq!(worker.num_tokens(), 2);
 //!

--- a/vibrato/src/sentence.rs
+++ b/vibrato/src/sentence.rs
@@ -8,7 +8,7 @@ pub struct Sentence {
     chars: Vec<char>,
     c2b: Vec<usize>,
     cinfos: Vec<CharInfo>,
-    groupable: Vec<u16>,
+    groupable: Vec<usize>,
 }
 
 impl Sentence {
@@ -35,7 +35,8 @@ impl Sentence {
 
     pub fn compile(&mut self, char_prop: &CharProperty) -> Result<()> {
         self.compute_basic();
-        if usize::from(MAX_SENTENCE_LENGTH) < self.chars().len() {
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if MAX_SENTENCE_LENGTH < self.chars().len() {
             self.clear();
             return Err(VibratoError::invalid_argument(
                 "input",
@@ -94,24 +95,23 @@ impl Sentence {
     }
 
     #[inline(always)]
-    pub fn len_char(&self) -> u16 {
-        // Safety: self.chars.len() is always no more than MAX_SENTENCE_LENGTH.
-        unsafe { u16::try_from(self.chars.len()).unwrap_unchecked() }
+    pub fn len_char(&self) -> usize {
+        self.chars.len()
     }
 
     #[inline(always)]
-    pub fn byte_position(&self, pos_char: u16) -> usize {
-        self.c2b[usize::from(pos_char)]
+    pub fn byte_position(&self, pos_char: usize) -> usize {
+        self.c2b[pos_char]
     }
 
     #[inline(always)]
-    pub fn char_info(&self, pos_char: u16) -> CharInfo {
-        self.cinfos[usize::from(pos_char)]
+    pub fn char_info(&self, pos_char: usize) -> CharInfo {
+        self.cinfos[pos_char]
     }
 
     #[inline(always)]
-    pub fn groupable(&self, pos_char: u16) -> u16 {
-        self.groupable[usize::from(pos_char)]
+    pub fn groupable(&self, pos_char: usize) -> usize {
+        self.groupable[pos_char]
     }
 }
 

--- a/vibrato/src/sentence.rs
+++ b/vibrato/src/sentence.rs
@@ -35,17 +35,6 @@ impl Sentence {
 
     pub fn compile(&mut self, char_prop: &CharProperty) -> Result<()> {
         self.compute_basic();
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if MAX_SENTENCE_LENGTH < self.chars().len() {
-            self.clear();
-            return Err(VibratoError::invalid_argument(
-                "input",
-                format!(
-                    "An input sentence must not have a length no more than {}",
-                    MAX_SENTENCE_LENGTH
-                ),
-            ));
-        }
         self.compute_categories(char_prop);
         self.compute_groupable();
         Ok(())

--- a/vibrato/src/sentence.rs
+++ b/vibrato/src/sentence.rs
@@ -1,6 +1,4 @@
-use crate::common::MAX_SENTENCE_LENGTH;
 use crate::dictionary::character::{CharInfo, CharProperty};
-use crate::errors::{Result, VibratoError};
 
 #[derive(Default, Clone, Debug)]
 pub struct Sentence {
@@ -33,11 +31,10 @@ impl Sentence {
         self.input.push_str(input.as_ref());
     }
 
-    pub fn compile(&mut self, char_prop: &CharProperty) -> Result<()> {
+    pub fn compile(&mut self, char_prop: &CharProperty) {
         self.compute_basic();
         self.compute_categories(char_prop);
         self.compute_groupable();
-        Ok(())
     }
 
     fn compute_basic(&mut self) {

--- a/vibrato/src/tests/tokenizer.rs
+++ b/vibrato/src/tests/tokenizer.rs
@@ -19,7 +19,7 @@ fn test_tokenize_tokyo() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("東京都").unwrap();
+    worker.reset_sentence("東京都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
@@ -53,7 +53,7 @@ fn test_tokenize_kyotokyo() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("京都東京都京都").unwrap();
+    worker.reset_sentence("京都東京都京都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 3);
 
@@ -117,7 +117,7 @@ fn test_tokenize_kyotokyo_with_user() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("京都東京都京都").unwrap();
+    worker.reset_sentence("京都東京都京都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 2);
 
@@ -162,7 +162,7 @@ fn test_tokenize_tokyoto_with_space() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("東京 都").unwrap();
+    worker.reset_sentence("東京 都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 3);
 
@@ -218,7 +218,7 @@ fn test_tokenize_tokyoto_with_space_ignored() {
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("東京 都").unwrap();
+    worker.reset_sentence("東京 都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 2);
 
@@ -263,7 +263,7 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("東京   都").unwrap();
+    worker.reset_sentence("東京   都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 2);
 
@@ -308,7 +308,7 @@ fn test_tokenize_tokyoto_startswith_spaces_ignored() {
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("   東京都").unwrap();
+    worker.reset_sentence("   東京都");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
@@ -342,7 +342,7 @@ fn test_tokenize_tokyoto_endswith_spaces_ignored() {
 
     let tokenizer = Tokenizer::new(dict).ignore_space(true).unwrap();
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("東京都   ").unwrap();
+    worker.reset_sentence("東京都   ");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
@@ -376,7 +376,7 @@ fn test_tokenize_kampersanda() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("kampersanda").unwrap();
+    worker.reset_sentence("kampersanda");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
@@ -409,7 +409,7 @@ fn test_tokenize_kampersanda_with_user() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("kampersanda").unwrap();
+    worker.reset_sentence("kampersanda");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
@@ -443,7 +443,7 @@ fn test_tokenize_kampersanda_with_max_grouping() {
         .unwrap()
         .max_grouping_len(9);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("kampersanda").unwrap();
+    worker.reset_sentence("kampersanda");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 2);
 
@@ -485,7 +485,7 @@ fn test_tokenize_tokyoken() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("東京県に行く").unwrap();
+    worker.reset_sentence("東京県に行く");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 4);
 }
@@ -503,7 +503,7 @@ fn test_tokenize_kanjinumeric() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("一橋大学大学院").unwrap();
+    worker.reset_sentence("一橋大学大学院");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
@@ -528,7 +528,7 @@ fn test_tokenize_empty() {
 
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
-    worker.reset_sentence("").unwrap();
+    worker.reset_sentence("");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 0);
 }
@@ -546,19 +546,19 @@ fn test_tokenize_repeat() {
     let tokenizer = Tokenizer::new(dict);
     let mut worker = tokenizer.new_worker();
 
-    worker.reset_sentence("東京に行く").unwrap();
+    worker.reset_sentence("東京に行く");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 3);
 
-    worker.reset_sentence("一橋大学大学院").unwrap();
+    worker.reset_sentence("一橋大学大学院");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 
-    worker.reset_sentence("").unwrap();
+    worker.reset_sentence("");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 0);
 
-    worker.reset_sentence("kampersanda").unwrap();
+    worker.reset_sentence("kampersanda");
     worker.tokenize();
     assert_eq!(worker.num_tokens(), 1);
 }

--- a/vibrato/src/token.rs
+++ b/vibrato/src/token.rs
@@ -158,7 +158,7 @@ mod tests {
 
         let tokenizer = Tokenizer::new(dict);
         let mut worker = tokenizer.new_worker();
-        worker.reset_sentence("自然言語処理").unwrap();
+        worker.reset_sentence("自然言語処理");
         worker.tokenize();
         assert_eq!(worker.num_tokens(), 2);
 

--- a/vibrato/src/token.rs
+++ b/vibrato/src/token.rs
@@ -20,7 +20,7 @@ impl<'a> Token<'a> {
     #[inline(always)]
     pub fn range_char(&self) -> Range<usize> {
         let (end_word, node) = &self.worker.top_nodes[self.index];
-        usize::from(node.start_word)..usize::from(*end_word)
+        node.start_word..*end_word
     }
 
     /// Gets the position range of the token in bytes.

--- a/vibrato/src/tokenizer.rs
+++ b/vibrato/src/tokenizer.rs
@@ -16,7 +16,7 @@ pub struct Tokenizer {
     dict: Dictionary,
     // For the MeCab compatibility
     space_cateset: Option<u32>,
-    max_grouping_len: Option<u16>,
+    max_grouping_len: Option<usize>,
 }
 
 impl Tokenizer {
@@ -66,9 +66,10 @@ impl Tokenizer {
     ///
     ///  - `max_grouping_len`: The maximum grouping length for unknown words.
     ///                        The default value is 0, indicating the infinity length.
-    pub fn max_grouping_len(mut self, max_grouping_len: usize) -> Self {
-        if max_grouping_len != 0 && max_grouping_len <= usize::from(MAX_SENTENCE_LENGTH) {
-            self.max_grouping_len = Some(max_grouping_len as u16);
+    pub const fn max_grouping_len(mut self, max_grouping_len: usize) -> Self {
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if max_grouping_len != 0 && max_grouping_len <= MAX_SENTENCE_LENGTH {
+            self.max_grouping_len = Some(max_grouping_len);
         } else {
             self.max_grouping_len = None;
         }
@@ -157,8 +158,8 @@ impl Tokenizer {
         &self,
         sent: &Sentence,
         lattice: &mut Lattice,
-        start_node: u16,
-        start_word: u16,
+        start_node: usize,
+        start_word: usize,
         connector: &C,
     ) where
         C: ConnectorCost,
@@ -167,7 +168,7 @@ impl Tokenizer {
 
         // Safety: `start_word < sent.len_char()` is already checked in `build_lattice()`.
         debug_assert!(start_word < sent.len_char());
-        let suffix = unsafe { sent.chars().get_unchecked(usize::from(start_word)..) };
+        let suffix = unsafe { sent.chars().get_unchecked(start_word..) };
 
         if let Some(user_lexicon) = self.dict.user_lexicon() {
             for m in user_lexicon.common_prefix_iterator(suffix) {
@@ -219,8 +220,8 @@ impl Tokenizer {
         &self,
         sent: &Sentence,
         lattice: &mut Lattice,
-        start_node: u16,
-        start_word: u16,
+        start_node: usize,
+        start_word: usize,
         connector: &C,
     ) where
         C: ConnectorCost,
@@ -229,7 +230,7 @@ impl Tokenizer {
 
         // Safety: `start_word < sent.len_char()` is already checked in `build_lattice()`.
         debug_assert!(start_word < sent.len_char());
-        let suffix = sent.chars().get_unchecked(usize::from(start_word)..);
+        let suffix = sent.chars().get_unchecked(start_word..);
 
         if let Some(user_lexicon) = self.dict.user_lexicon() {
             for m in user_lexicon.common_prefix_iterator_unchecked(suffix) {

--- a/vibrato/src/tokenizer.rs
+++ b/vibrato/src/tokenizer.rs
@@ -9,8 +9,6 @@ use crate::sentence::Sentence;
 use crate::tokenizer::lattice::Lattice;
 use crate::tokenizer::worker::Worker;
 
-use crate::common::MAX_SENTENCE_LENGTH;
-
 /// Tokenizer.
 pub struct Tokenizer {
     dict: Dictionary,
@@ -67,8 +65,7 @@ impl Tokenizer {
     ///  - `max_grouping_len`: The maximum grouping length for unknown words.
     ///                        The default value is 0, indicating the infinity length.
     pub const fn max_grouping_len(mut self, max_grouping_len: usize) -> Self {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if max_grouping_len != 0 && max_grouping_len <= MAX_SENTENCE_LENGTH {
+        if max_grouping_len != 0 {
             self.max_grouping_len = Some(max_grouping_len);
         } else {
             self.max_grouping_len = None;

--- a/vibrato/src/tokenizer.rs
+++ b/vibrato/src/tokenizer.rs
@@ -305,7 +305,7 @@ mod tests {
 
         let tokenizer = Tokenizer::new(dict);
         let mut worker = tokenizer.new_worker();
-        worker.reset_sentence("自然言語処理").unwrap();
+        worker.reset_sentence("自然言語処理");
         worker.tokenize();
         assert_eq!(worker.num_tokens(), 2);
 
@@ -348,7 +348,7 @@ mod tests {
 
         let tokenizer = Tokenizer::new(dict);
         let mut worker = tokenizer.new_worker();
-        worker.reset_sentence("自然日本語処理").unwrap();
+        worker.reset_sentence("自然日本語処理");
         worker.tokenize();
         assert_eq!(worker.num_tokens(), 2);
 
@@ -391,7 +391,7 @@ mod tests {
 
         let tokenizer = Tokenizer::new(dict);
         let mut worker = tokenizer.new_worker();
-        worker.reset_sentence("不自然言語処理").unwrap();
+        worker.reset_sentence("不自然言語処理");
         worker.tokenize();
         assert_eq!(worker.num_tokens(), 2);
 
@@ -434,7 +434,7 @@ mod tests {
 
         let tokenizer = Tokenizer::new(dict);
         let mut worker = tokenizer.new_worker();
-        worker.reset_sentence("").unwrap();
+        worker.reset_sentence("");
         worker.tokenize();
         assert_eq!(worker.num_tokens(), 0);
     }

--- a/vibrato/src/tokenizer/lattice.rs
+++ b/vibrato/src/tokenizer/lattice.rs
@@ -14,8 +14,8 @@ const INVALID_IDX: u16 = u16::MAX;
 pub struct Node {
     pub word_id: u32,
     pub lex_type: LexType, // 8 bits
-    pub start_node: u16,
-    pub start_word: u16,
+    pub start_node: usize,
+    pub start_word: usize,
     pub left_id: u16,
     pub right_id: u16,
     pub min_idx: u16,
@@ -39,24 +39,24 @@ impl Node {
 pub struct Lattice {
     ends: Vec<Vec<Node>>,
     eos: Option<Node>,
-    len_char: u16, // needed for avoiding to free ends
+    len_char: usize, // needed for avoiding to free ends
 }
 
 impl Lattice {
-    pub fn reset(&mut self, len_char: u16) {
+    pub fn reset(&mut self, len_char: usize) {
         Self::reset_vec(&mut self.ends, len_char + 1);
         self.len_char = len_char;
         self.eos = None;
         self.insert_bos();
     }
 
-    fn reset_vec<T>(data: &mut Vec<Vec<T>>, new_len: u16) {
+    fn reset_vec<T>(data: &mut Vec<Vec<T>>, new_len: usize) {
         for v in data.iter_mut() {
             v.clear();
         }
-        let cur_len = data.len() as u16;
+        let cur_len = data.len();
         if cur_len <= new_len {
-            data.reserve(usize::from(new_len - cur_len));
+            data.reserve(new_len - cur_len);
             for _ in cur_len..new_len {
                 data.push(Vec::with_capacity(16))
             }
@@ -65,7 +65,7 @@ impl Lattice {
 
     /// Returns the number of characters of the set sentence.
     #[inline(always)]
-    pub const fn len_char(&self) -> u16 {
+    pub const fn len_char(&self) -> usize {
         self.len_char
     }
 
@@ -82,7 +82,7 @@ impl Lattice {
         });
     }
 
-    pub fn insert_eos<C>(&mut self, start_node: u16, connector: &C)
+    pub fn insert_eos<C>(&mut self, start_node: usize, connector: &C)
     where
         C: ConnectorCost,
     {
@@ -100,7 +100,7 @@ impl Lattice {
         });
     }
 
-    pub unsafe fn insert_eos_unchecked<C>(&mut self, start_node: u16, connector: &C)
+    pub unsafe fn insert_eos_unchecked<C>(&mut self, start_node: usize, connector: &C)
     where
         C: ConnectorCost,
     {
@@ -120,9 +120,9 @@ impl Lattice {
 
     pub fn insert_node<C>(
         &mut self,
-        start_node: u16,
-        start_word: u16,
-        end_word: u16,
+        start_node: usize,
+        start_word: usize,
+        end_word: usize,
         word_idx: WordIdx,
         word_param: WordParam,
         connector: &C,
@@ -132,7 +132,7 @@ impl Lattice {
         debug_assert!(start_node <= start_word);
         debug_assert!(start_word < end_word);
         let (min_idx, min_cost) = self.search_min_node(start_node, word_param.left_id, connector);
-        self.ends[usize::from(end_word)].push(Node {
+        self.ends[end_word].push(Node {
             word_id: word_idx.word_id,
             lex_type: word_idx.lex_type,
             start_node,
@@ -146,9 +146,9 @@ impl Lattice {
 
     pub unsafe fn insert_node_unchecked<C>(
         &mut self,
-        start_node: u16,
-        start_word: u16,
-        end_word: u16,
+        start_node: usize,
+        start_word: usize,
+        end_word: usize,
         word_idx: WordIdx,
         word_param: WordParam,
         connector: &C,
@@ -159,7 +159,7 @@ impl Lattice {
         debug_assert!(start_word < end_word);
         let (min_idx, min_cost) =
             self.search_min_node_unchecked(start_node, word_param.left_id, connector);
-        self.ends[usize::from(end_word)].push(Node {
+        self.ends[end_word].push(Node {
             word_id: word_idx.word_id,
             lex_type: word_idx.lex_type,
             start_node,
@@ -171,15 +171,15 @@ impl Lattice {
         });
     }
 
-    fn search_min_node<C>(&self, start_node: u16, left_id: u16, connector: &C) -> (u16, i32)
+    fn search_min_node<C>(&self, start_node: usize, left_id: u16, connector: &C) -> (u16, i32)
     where
         C: ConnectorCost,
     {
-        debug_assert!(!self.ends[usize::from(start_node)].is_empty());
+        debug_assert!(!self.ends[start_node].is_empty());
 
         let mut min_idx = INVALID_IDX;
         let mut min_cost = MAX_COST;
-        for (i, left_node) in self.ends[usize::from(start_node)].iter().enumerate() {
+        for (i, left_node) in self.ends[start_node].iter().enumerate() {
             debug_assert!(left_node.is_connected_to_bos());
             let conn_cost = connector.cost(left_node.right_id, left_id);
             let new_cost = left_node.min_cost + conn_cost;
@@ -197,18 +197,18 @@ impl Lattice {
 
     unsafe fn search_min_node_unchecked<C>(
         &self,
-        start_node: u16,
+        start_node: usize,
         left_id: u16,
         connector: &C,
     ) -> (u16, i32)
     where
         C: ConnectorCost,
     {
-        debug_assert!(!self.ends[usize::from(start_node)].is_empty());
+        debug_assert!(!self.ends[start_node].is_empty());
 
         let mut min_idx = INVALID_IDX;
         let mut min_cost = MAX_COST;
-        for (i, left_node) in self.ends[usize::from(start_node)].iter().enumerate() {
+        for (i, left_node) in self.ends[start_node].iter().enumerate() {
             debug_assert!(left_node.is_connected_to_bos());
             let conn_cost = connector.cost_unchecked(left_node.right_id, left_id);
             let new_cost = left_node.min_cost + conn_cost;
@@ -226,19 +226,16 @@ impl Lattice {
 
     /// Checks if there exist at least one at the word end boundary
     #[inline(always)]
-    pub fn has_previous_node(&self, i: u16) -> bool {
-        self.ends
-            .get(usize::from(i))
-            .map(|d| !d.is_empty())
-            .unwrap_or(false)
+    pub fn has_previous_node(&self, i: usize) -> bool {
+        self.ends.get(i).map(|d| !d.is_empty()).unwrap_or(false)
     }
 
-    pub fn append_top_nodes(&self, top_nodes: &mut Vec<(u16, Node)>) {
+    pub fn append_top_nodes(&self, top_nodes: &mut Vec<(usize, Node)>) {
         let eos = self.eos.as_ref().unwrap();
         let mut end_node = eos.start_node;
         let mut min_idx = eos.min_idx;
         while end_node != 0 {
-            let node = &self.ends[usize::from(end_node)][usize::from(min_idx)];
+            let node = &self.ends[end_node][usize::from(min_idx)];
             top_nodes.push((end_node, node.clone()));
             (end_node, min_idx) = (node.start_node, node.min_idx);
         }
@@ -246,15 +243,15 @@ impl Lattice {
 
     pub fn add_connid_counts(&self, counter: &mut ConnIdCounter) {
         for end_char in 1..=self.len_char() {
-            for r_node in &self.ends[usize::from(end_char)] {
+            for r_node in &self.ends[end_char] {
                 let start_node = r_node.start_node;
-                for l_node in &self.ends[usize::from(start_node)] {
+                for l_node in &self.ends[start_node] {
                     counter.add(r_node.left_id, l_node.right_id, 1);
                 }
             }
         }
         let r_node = self.eos.as_ref().unwrap();
-        for l_node in &self.ends[usize::from(self.len_char())] {
+        for l_node in &self.ends[self.len_char()] {
             counter.add(r_node.left_id, l_node.right_id, 1);
         }
     }
@@ -263,10 +260,7 @@ impl Lattice {
 impl std::fmt::Debug for Lattice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Lattice {{ eos: {:?}, ends: [", &self.eos)?;
-        for (i, e) in self.ends[..=usize::from(self.len_char())]
-            .iter()
-            .enumerate()
-        {
+        for (i, e) in self.ends[..=self.len_char()].iter().enumerate() {
             writeln!(f, "{} => {:?}", i, e)?;
         }
         writeln!(f, "]}}")

--- a/vibrato/src/tokenizer/worker.rs
+++ b/vibrato/src/tokenizer/worker.rs
@@ -15,7 +15,7 @@ pub struct Worker<'a> {
     pub(crate) tokenizer: &'a Tokenizer,
     pub(crate) sent: Sentence,
     pub(crate) lattice: Lattice,
-    pub(crate) top_nodes: Vec<(u16, Node)>,
+    pub(crate) top_nodes: Vec<(usize, Node)>,
     pub(crate) counter: Option<ConnIdCounter>,
 }
 

--- a/vibrato/src/tokenizer/worker.rs
+++ b/vibrato/src/tokenizer/worker.rs
@@ -31,12 +31,6 @@ impl<'a> Worker<'a> {
     }
 
     /// Resets the input sentence to be tokenized.
-    ///
-    /// # Errors
-    ///
-    /// When the input sentence includes characters more than
-    /// [`MAX_SENTENCE_LENGTH`](crate::common::MAX_SENTENCE_LENGTH),
-    /// an error will be returned.
     pub fn reset_sentence<S>(&mut self, input: S)
     where
         S: AsRef<str>,

--- a/vibrato/src/tokenizer/worker.rs
+++ b/vibrato/src/tokenizer/worker.rs
@@ -1,7 +1,6 @@
 //! Provider of a routine for tokenization.
 use crate::dictionary::connector::Connector;
 use crate::dictionary::mapper::{ConnIdCounter, ConnIdProbs};
-use crate::errors::Result;
 use crate::sentence::Sentence;
 use crate::token::{Token, TokenIter};
 use crate::tokenizer::lattice::{Lattice, Node};
@@ -38,7 +37,7 @@ impl<'a> Worker<'a> {
     /// When the input sentence includes characters more than
     /// [`MAX_SENTENCE_LENGTH`](crate::common::MAX_SENTENCE_LENGTH),
     /// an error will be returned.
-    pub fn reset_sentence<S>(&mut self, input: S) -> Result<()>
+    pub fn reset_sentence<S>(&mut self, input: S)
     where
         S: AsRef<str>,
     {
@@ -47,9 +46,8 @@ impl<'a> Worker<'a> {
         let input = input.as_ref();
         if !input.is_empty() {
             self.sent.set_sentence(input);
-            self.sent.compile(self.tokenizer.dictionary().char_prop())?;
+            self.sent.compile(self.tokenizer.dictionary().char_prop());
         }
-        Ok(())
     }
 
     /// Tokenizes the input sentence set in `state`,

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -89,8 +89,6 @@ pub use crate::trainer::model::Model;
 use crate::trainer::model::ModelData;
 use crate::utils::{self, FromU32};
 
-use crate::common::MAX_SENTENCE_LENGTH;
-
 /// Trainer of morphological analyzer.
 pub struct Trainer {
     config: TrainerConfig,
@@ -251,8 +249,7 @@ impl Trainer {
     ///  * `max_grouping_len` - The maximum grouping length for unknown words.
     ///                         The default value is 0, indicating the infinity length.
     pub const fn max_grouping_len(mut self, max_grouping_len: usize) -> Self {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if max_grouping_len != 0 && max_grouping_len <= MAX_SENTENCE_LENGTH {
+        if max_grouping_len != 0 {
             self.max_grouping_len = Some(max_grouping_len);
         } else {
             self.max_grouping_len = None;

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -60,7 +60,7 @@
 //! let tokenizer = Tokenizer::new(dict);
 //! let mut worker = tokenizer.new_worker();
 //!
-//! worker.reset_sentence("外国人参政権")?;
+//! worker.reset_sentence("外国人参政権");
 //! worker.tokenize();
 //! assert_eq!(worker.num_tokens(), 4); // 外国/人/参政/権
 //! # Ok(())
@@ -374,7 +374,7 @@ impl Trainer {
     pub fn train(mut self, mut corpus: Corpus) -> Result<Model> {
         let mut lattices = vec![];
         for example in &mut corpus.examples {
-            example.sentence.compile(self.config.dict.char_prop())?;
+            example.sentence.compile(self.config.dict.char_prop());
             lattices.push(self.build_lattice(example)?);
         }
 


### PR DESCRIPTION
Fixes #43 and #70 

The use of u16 is almost no contribution to improving speed and has the greater disadvantage of imposing restrictions on the API.

main branch:
```
$ cargo run --release -p benchmark -- -i matrix-conn.bin < ~/resources/raw.txt
[benchmark/src/main.rs:60] n_words = 13003250
Warmup: 0.4851920423000001
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
Number_of_sentences: 59983
Elapsed_seconds_to_tokenize_all_sentences: [0.4814435521,0.4841883191500001,0.4873885917]
```

this branch:
```
$ cargo run --release -p benchmark -- -i matrix-conn.bin < ~/resources/raw.txt 
[benchmark/src/main.rs:60] n_words = 13003250
Warmup: 0.4852931217
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
[benchmark/src/main.rs:60] n_words = 13003250
Number_of_sentences: 59983
Elapsed_seconds_to_tokenize_all_sentences: [0.48239738660000003,0.48523912847500006,0.48852848359999995]
```