### PR TITLE
Add a builder for system dictionary

### DIFF
--- a/prepare/src/system.rs
+++ b/prepare/src/system.rs
@@ -4,7 +4,7 @@ use std::io::BufWriter;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use vibrato::dictionary::Dictionary;
+use vibrato::dictionary::SystemDictionaryBuilder;
 
 use clap::{CommandFactory, ErrorKind, Parser};
 
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     eprintln!("Compiling the system dictionary...");
     let start = Instant::now();
     let dict = if let Some(matrix_in) = args.matrix_in {
-        Dictionary::from_readers(
+        SystemDictionaryBuilder::from_readers(
             File::open(args.lexicon_in)?,
             File::open(matrix_in)?,
             File::open(args.char_in)?,
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         args.bigram_left_in,
         args.bigram_cost_in,
     ) {
-        Dictionary::from_readers_with_bigram_info(
+        SystemDictionaryBuilder::from_readers_with_bigram_info(
             File::open(args.lexicon_in)?,
             File::open(bigram_right_in)?,
             File::open(bigram_left_in)?,

--- a/vibrato/src/dictionary.rs
+++ b/vibrato/src/dictionary.rs
@@ -178,7 +178,7 @@ impl Dictionary {
     /// # Errors
     ///
     /// [`VibratoError`] is returned when an input format is invalid.
-    pub fn user_lexicon_from_reader<R>(mut self, user_lexicon_rdr: Option<R>) -> Result<Dictionary>
+    pub fn user_lexicon_from_reader<R>(mut self, user_lexicon_rdr: Option<R>) -> Result<Self>
     where
         R: Read,
     {

--- a/vibrato/src/dictionary.rs
+++ b/vibrato/src/dictionary.rs
@@ -190,7 +190,7 @@ impl Dictionary {
             if !user_lexicon.verify(self.connector()) {
                 return Err(VibratoError::invalid_argument(
                     "user_lexicon_rdr",
-                    "user_lexicon_rdr includes invalid connection ids.",
+                    "includes invalid connection ids.",
                 ));
             }
             self.data.user_lexicon = Some(user_lexicon);

--- a/vibrato/src/dictionary/builder.rs
+++ b/vibrato/src/dictionary/builder.rs
@@ -13,7 +13,7 @@ use super::lexicon::RawWordEntry;
 pub struct SystemDictionaryBuilder {}
 
 impl SystemDictionaryBuilder {
-    pub(crate) fn new(
+    pub(crate) fn build(
         system_word_entries: &[RawWordEntry],
         connector: ConnectorWrapper,
         char_prop: CharProperty,
@@ -78,7 +78,7 @@ impl SystemDictionaryBuilder {
         let char_prop = CharProperty::from_reader(char_prop_rdr)?;
         let unk_handler = UnkHandler::from_reader(unk_handler_rdr, &char_prop)?;
 
-        Self::new(
+        Self::build(
             &system_word_entries,
             ConnectorWrapper::Matrix(connector),
             char_prop,
@@ -125,7 +125,7 @@ impl SystemDictionaryBuilder {
         let char_prop = CharProperty::from_reader(char_prop_rdr)?;
         let unk_handler = UnkHandler::from_reader(unk_handler_rdr, &char_prop)?;
 
-        Self::new(
+        Self::build(
             &system_word_entries,
             ConnectorWrapper::Raw(connector),
             char_prop,

--- a/vibrato/src/dictionary/builder.rs
+++ b/vibrato/src/dictionary/builder.rs
@@ -1,21 +1,24 @@
+//! Builders for [`Dictionary`].
 use std::io::Read;
 
 use crate::dictionary::connector::{MatrixConnector, RawConnector};
 use crate::dictionary::{
-    CharProperty, ConnIdMapper, Connector, ConnectorWrapper, Dictionary, DictionaryInner, LexType,
-    Lexicon, UnkHandler,
+    CharProperty, ConnectorWrapper, Dictionary, DictionaryInner, LexType, Lexicon, UnkHandler,
 };
 use crate::errors::{Result, VibratoError};
 
 use super::lexicon::RawWordEntry;
 
-impl Dictionary {
+/// Builder for [`Dictionary`] from system lexicon entries.
+pub struct SystemDictionaryBuilder {}
+
+impl SystemDictionaryBuilder {
     pub(crate) fn new(
         system_word_entries: &[RawWordEntry],
         connector: ConnectorWrapper,
         char_prop: CharProperty,
         unk_handler: UnkHandler,
-    ) -> Result<Self> {
+    ) -> Result<Dictionary> {
         let system_lexicon = Lexicon::from_entries(system_word_entries, LexType::System)?;
 
         if !system_lexicon.verify(&connector) {
@@ -31,7 +34,7 @@ impl Dictionary {
             ));
         }
 
-        Ok(Self {
+        Ok(Dictionary {
             data: DictionaryInner {
                 system_lexicon,
                 user_lexicon: None,
@@ -44,7 +47,7 @@ impl Dictionary {
         })
     }
 
-    /// Creates a new instance from readers in the MeCab format.
+    /// Creates a new [`Dictionary`] from readers of system entries in the MeCab format.
     ///
     /// # Arguments
     ///
@@ -61,7 +64,7 @@ impl Dictionary {
         connector_rdr: C,
         char_prop_rdr: P,
         unk_handler_rdr: U,
-    ) -> Result<Self>
+    ) -> Result<Dictionary>
     where
         S: Read,
         C: Read,
@@ -83,7 +86,8 @@ impl Dictionary {
         )
     }
 
-    /// Creates a new instance from readers with the detailed bi-gram information.
+    /// Creates a new [`Dictionary`] from readers of system entries
+    /// with the detailed bi-gram information.
     ///
     /// # Arguments
     ///
@@ -104,7 +108,7 @@ impl Dictionary {
         bigram_cost_rdr: C,
         char_prop_rdr: P,
         unk_handler_rdr: U,
-    ) -> Result<Self>
+    ) -> Result<Dictionary>
     where
         S: Read,
         R: Read,
@@ -128,68 +132,6 @@ impl Dictionary {
             unk_handler,
         )
     }
-
-    /// Resets the user dictionary from a reader.
-    ///
-    /// # Arguments
-    ///
-    ///  - `user_lexicon_rdr`: A reader of a lexicon file `*.csv` in the MeCab format.
-    ///                        If `None`, clear the current user dictionary.
-    ///
-    /// # Errors
-    ///
-    /// [`VibratoError`] is returned when an input format is invalid.
-    pub fn user_lexicon_from_reader<R>(mut self, user_lexicon_rdr: Option<R>) -> Result<Self>
-    where
-        R: Read,
-    {
-        if let Some(user_lexicon_rdr) = user_lexicon_rdr {
-            let mut user_lexicon = Lexicon::from_reader(user_lexicon_rdr, LexType::User)?;
-            if let Some(mapper) = self.data.mapper.as_ref() {
-                user_lexicon.do_mapping(mapper);
-            }
-            if !user_lexicon.verify(self.connector()) {
-                return Err(VibratoError::invalid_argument(
-                    "user_lexicon_rdr",
-                    "user_lexicon_rdr includes invalid connection ids.",
-                ));
-            }
-            self.data.user_lexicon = Some(user_lexicon);
-        } else {
-            self.data.user_lexicon = None;
-        }
-        Ok(self)
-    }
-
-    /// Edits connection ids with the given mappings.
-    ///
-    /// # Arguments
-    ///
-    ///  - `lmap/rmap`: An iterator of mappings of left/right ids, where
-    ///                 the `i`-th item (1-origin) indicates a new id mapped from id `i`.
-    ///
-    /// # Errors
-    ///
-    /// [`VibratoError`] is returned when
-    ///  - a new id of [`BOS_EOS_CONNECTION_ID`](crate::common::BOS_EOS_CONNECTION_ID)
-    ///    is included,
-    ///  - new ids are duplicated, or
-    ///  - the set of new ids are not same as that of old ids.
-    pub fn mapping_from_iter<L, R>(mut self, lmap: L, rmap: R) -> Result<Self>
-    where
-        L: IntoIterator<Item = u16>,
-        R: IntoIterator<Item = u16>,
-    {
-        let mapper = ConnIdMapper::from_iter(lmap, rmap)?;
-        self.data.system_lexicon.do_mapping(&mapper);
-        if let Some(user_lexicon) = self.data.user_lexicon.as_mut() {
-            user_lexicon.do_mapping(&mapper);
-        }
-        self.data.connector.do_mapping(&mapper);
-        self.data.unk_handler.do_mapping(&mapper);
-        self.data.mapper = Some(mapper);
-        Ok(self)
-    }
 }
 
 #[cfg(test)]
@@ -203,7 +145,7 @@ mod tests {
         let char_def = "DEFAULT 0 1 0";
         let unk_def = "DEFAULT,0,0,100,*";
 
-        let result = Dictionary::from_readers(
+        let result = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),
@@ -220,7 +162,7 @@ mod tests {
         let char_def = "DEFAULT 0 1 0";
         let unk_def = "DEFAULT,1,1,100,*";
 
-        let result = Dictionary::from_readers(
+        let result = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -10,10 +10,10 @@
 //! use std::fs::File;
 //! use std::io::{BufRead, BufReader};
 //!
-//! use vibrato::{Dictionary, Tokenizer};
+//! use vibrato::{SystemDictionaryBuilder, Tokenizer};
 //!
 //! // Loads a set of raw dictionary files
-//! let dict = Dictionary::from_readers(
+//! let dict = SystemDictionaryBuilder::from_readers(
 //!     File::open("src/tests/resources/lex.csv")?,
 //!     File::open("src/tests/resources/matrix.def")?,
 //!     File::open("src/tests/resources/char.def")?,
@@ -62,5 +62,5 @@ mod test_utils;
 #[cfg(test)]
 mod tests;
 
-pub use dictionary::Dictionary;
+pub use dictionary::{Dictionary, SystemDictionaryBuilder};
 pub use tokenizer::Tokenizer;

--- a/vibrato/src/tests/tokenizer.rs
+++ b/vibrato/src/tests/tokenizer.rs
@@ -1,4 +1,4 @@
-use crate::dictionary::Dictionary;
+use crate::dictionary::SystemDictionaryBuilder;
 use crate::Tokenizer;
 
 const LEX_CSV: &str = include_str!("./resources/lex.csv");
@@ -9,7 +9,7 @@ const UNK_DEF: &str = include_str!("./resources/unk.def");
 
 #[test]
 fn test_tokenize_tokyo() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -43,7 +43,7 @@ fn test_tokenize_tokyo() {
 
 #[test]
 fn test_tokenize_kyotokyo() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -105,7 +105,7 @@ fn test_tokenize_kyotokyo() {
 
 #[test]
 fn test_tokenize_kyotokyo_with_user() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -152,7 +152,7 @@ fn test_tokenize_kyotokyo_with_user() {
 
 #[test]
 fn test_tokenize_tokyoto_with_space() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -208,7 +208,7 @@ fn test_tokenize_tokyoto_with_space() {
 
 #[test]
 fn test_tokenize_tokyoto_with_space_ignored() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -253,7 +253,7 @@ fn test_tokenize_tokyoto_with_space_ignored() {
 
 #[test]
 fn test_tokenize_tokyoto_with_spaces_ignored() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -298,7 +298,7 @@ fn test_tokenize_tokyoto_with_spaces_ignored() {
 
 #[test]
 fn test_tokenize_tokyoto_startswith_spaces_ignored() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -332,7 +332,7 @@ fn test_tokenize_tokyoto_startswith_spaces_ignored() {
 
 #[test]
 fn test_tokenize_tokyoto_endswith_spaces_ignored() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -366,7 +366,7 @@ fn test_tokenize_tokyoto_endswith_spaces_ignored() {
 
 #[test]
 fn test_tokenize_kampersanda() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -397,7 +397,7 @@ fn test_tokenize_kampersanda() {
 
 #[test]
 fn test_tokenize_kampersanda_with_user() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -430,7 +430,7 @@ fn test_tokenize_kampersanda_with_user() {
 
 #[test]
 fn test_tokenize_kampersanda_with_max_grouping() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -475,7 +475,7 @@ fn test_tokenize_kampersanda_with_max_grouping() {
 
 #[test]
 fn test_tokenize_tokyoken() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -493,7 +493,7 @@ fn test_tokenize_tokyoken() {
 /// This test is to check if the category order in char.def is preserved.
 #[test]
 fn test_tokenize_kanjinumeric() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -518,7 +518,7 @@ fn test_tokenize_kanjinumeric() {
 
 #[test]
 fn test_tokenize_empty() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),
@@ -535,7 +535,7 @@ fn test_tokenize_empty() {
 
 #[test]
 fn test_tokenize_repeat() {
-    let dict = Dictionary::from_readers(
+    let dict = SystemDictionaryBuilder::from_readers(
         LEX_CSV.as_bytes(),
         MATRIX_DEF.as_bytes(),
         CHAR_DEF.as_bytes(),

--- a/vibrato/src/token.rs
+++ b/vibrato/src/token.rs
@@ -148,7 +148,7 @@ mod tests {
         let char_def = "DEFAULT 0 1 0";
         let unk_def = "DEFAULT,0,0,100,*";
 
-        let dict = Dictionary::from_readers(
+        let dict = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),

--- a/vibrato/src/tokenizer.rs
+++ b/vibrato/src/tokenizer.rs
@@ -284,6 +284,8 @@ impl Tokenizer {
 mod tests {
     use super::*;
 
+    use crate::dictionary::SystemDictionaryBuilder;
+
     #[test]
     fn test_tokenize_1() {
         let lexicon_csv = "自然,0,0,1,sizen
@@ -295,7 +297,7 @@ mod tests {
         let char_def = "DEFAULT 0 1 0";
         let unk_def = "DEFAULT,0,0,100,*";
 
-        let dict = Dictionary::from_readers(
+        let dict = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),
@@ -338,7 +340,7 @@ mod tests {
         let char_def = "DEFAULT 0 1 0";
         let unk_def = "DEFAULT,0,0,100,*";
 
-        let dict = Dictionary::from_readers(
+        let dict = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),
@@ -381,7 +383,7 @@ mod tests {
         let char_def = "DEFAULT 0 0 3";
         let unk_def = "DEFAULT,0,0,100,*";
 
-        let dict = Dictionary::from_readers(
+        let dict = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),
@@ -424,7 +426,7 @@ mod tests {
         let char_def = "DEFAULT 0 0 3";
         let unk_def = "DEFAULT,0,0,100,*";
 
-        let dict = Dictionary::from_readers(
+        let dict = SystemDictionaryBuilder::from_readers(
             lexicon_csv.as_bytes(),
             matrix_def.as_bytes(),
             char_def.as_bytes(),

--- a/vibrato/src/trainer.rs
+++ b/vibrato/src/trainer.rs
@@ -6,7 +6,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::fs::File;
 //! use vibrato::trainer::{Corpus, Trainer, TrainerConfig};
-//! use vibrato::{Dictionary, Tokenizer};
+//! use vibrato::{SystemDictionaryBuilder, Tokenizer};
 //!
 //! // Loads configurations
 //! let lexicon_rdr = File::open("src/tests/resources/train_lex.csv")?;
@@ -50,7 +50,7 @@
 //!
 //! // Loads trained model
 //! let char_prop_rdr = File::open("src/tests/resources/char.def")?;
-//! let dict = Dictionary::from_readers(
+//! let dict = SystemDictionaryBuilder::from_readers(
 //!     &*lexicon_trained,
 //!     &*connector_trained,
 //!     char_prop_rdr,

--- a/vibrato/src/trainer/config.rs
+++ b/vibrato/src/trainer/config.rs
@@ -11,7 +11,7 @@ use crate::dictionary::character::CharProperty;
 use crate::dictionary::connector::{ConnectorWrapper, MatrixConnector};
 use crate::dictionary::lexicon::Lexicon;
 use crate::dictionary::unknown::UnkHandler;
-use crate::dictionary::Dictionary;
+use crate::dictionary::{Dictionary, SystemDictionaryBuilder};
 use crate::errors::{Result, VibratoError};
 use crate::trainer::feature_extractor::FeatureExtractor;
 use crate::trainer::feature_rewriter::{FeatureRewriter, FeatureRewriterBuilder};
@@ -198,7 +198,7 @@ impl TrainerConfig {
         let char_prop = CharProperty::from_reader(char_prop_rdr)?;
         let unk_handler = UnkHandler::from_reader(unk_handler_rdr, &char_prop)?;
 
-        let dict = Dictionary::new(
+        let dict = SystemDictionaryBuilder::new(
             &lex_entries,
             ConnectorWrapper::Matrix(connector),
             char_prop,

--- a/vibrato/src/trainer/config.rs
+++ b/vibrato/src/trainer/config.rs
@@ -198,7 +198,7 @@ impl TrainerConfig {
         let char_prop = CharProperty::from_reader(char_prop_rdr)?;
         let unk_handler = UnkHandler::from_reader(unk_handler_rdr, &char_prop)?;
 
-        let dict = SystemDictionaryBuilder::new(
+        let dict = SystemDictionaryBuilder::build(
             &lex_entries,
             ConnectorWrapper::Matrix(connector),
             char_prop,


### PR DESCRIPTION
This PR addresses the issue https://github.com/daac-tools/vibrato/issues/52.

I'll plan to solve the issue with two steps:
1. Add a builder structure for `Dictionary`.
2. Add builder structures for submodules under `dictionary`.

This PR is the first step, which adds a struct `SystemDictionaryBuilder` for building `Dictionary` from system entries and moves functions `user_lexicon_from_reader` and `mapping_from_iter` under the module `dictionary`.