### PR TITLE
Ignore Nightly errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
         rust:
           - stable
           - beta
+          - nightly
     steps:
       - uses: actions/checkout@v2
       - name: Install latest stable
@@ -30,29 +31,34 @@ jobs:
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: check
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: fmt
           args: --all -- --check
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: clippy
           args: -- -D warnings -W clippy::nursery
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: test
           args: --release --all-features
 
       - name: Run cargo test with AVX2
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         env:
           RUSTFLAGS: '-C target-feature=+avx2'
         with:
@@ -61,6 +67,7 @@ jobs:
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: doc
           args: --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_UNSTABLE_SPARSE_REGISTRY: true
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
 
 jobs:
   build:
@@ -18,7 +19,6 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
     steps:
       - uses: actions/checkout@v2
       - name: Install latest stable
@@ -41,21 +41,18 @@ jobs:
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: clippy
           args: -- -D warnings -W clippy::nursery
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: test
           args: --release --all-features
 
       - name: Run cargo test with AVX2
         uses: actions-rs/cargo@v1
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
         env:
           RUSTFLAGS: '-C target-feature=+avx2'
         with:
@@ -64,7 +61,6 @@ jobs:
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: doc
           args: --no-deps


### PR DESCRIPTION
This PR ignores the nightly errors in CI following the discussion arising from the original PR, as follows.

---

It seems that CI fails due to the combination of bincode and sparse-registry flag.

<img width="904" alt="スクリーンショット 2022-10-17 15 45 51" src="https://user-images.githubusercontent.com/15042374/196109307-10330d2c-1eaf-4725-a69a-c88d256c8241.png">

This PR solves this problem for now by removing the flag.