### PR TITLE
Group feature IDs in 256-bit unit

### DIFF
--- a/vibrato/src/dictionary/connector/raw_connector/scorer.rs
+++ b/vibrato/src/dictionary/connector/raw_connector/scorer.rs
@@ -60,7 +60,7 @@ impl Decode for U31Array {
         let (a, b, c, d, e, f, g, h) = Decode::decode(decoder)?;
         let data = [a, b, c, d, e, f, g, h];
         for x in data {
-            if x >= i32::MAX as u32 {
+            if x > i32::MAX as u32 {
                 return Err(DecodeError::UnexpectedVariant {
                     type_name: "U31Array",
                     allowed: &AllowedEnumVariants::Range {

--- a/vibrato/src/dictionary/connector/raw_connector/scorer.rs
+++ b/vibrato/src/dictionary/connector/raw_connector/scorer.rs
@@ -6,10 +6,11 @@ use std::arch::x86_64::{self, __m256i};
 use bincode::{
     de::Decoder,
     enc::Encoder,
-    error::{AllowedEnumVariants, DecodeError, EncodeError},
+    error::{DecodeError, EncodeError},
     Decode, Encode,
 };
 
+use crate::num::U31;
 use crate::utils::FromU32;
 
 const UNUSED_CHECK: u32 = u32::MAX;
@@ -17,24 +18,23 @@ const UNUSED_CHECK: u32 = u32::MAX;
 pub const SIMD_SIZE: usize = 8;
 #[cfg(not(target_feature = "avx2"))]
 #[derive(Clone, Copy)]
-pub struct U31Array([u32; SIMD_SIZE]);
+pub struct U31x8([U31; SIMD_SIZE]);
 #[cfg(target_feature = "avx2")]
 #[derive(Clone, Copy)]
-pub struct U31Array(__m256i);
+pub struct U31x8(__m256i);
 
-impl U31Array {
-    pub fn to_simd_vec(data: &[u32]) -> Vec<Self> {
+impl U31x8 {
+    pub fn to_simd_vec(data: &[U31]) -> Vec<Self> {
         let mut result = vec![];
-        for &x in data {
-            assert!(x <= i32::MAX as u32);
-        }
         for xs in data.chunks(SIMD_SIZE) {
-            let mut array = [0; SIMD_SIZE];
+            let mut array = [U31::default(); SIMD_SIZE];
             array[..xs.len()].copy_from_slice(xs);
 
             #[cfg(not(target_feature = "avx2"))]
             result.push(Self(array));
 
+            // Safety
+            debug_assert_eq!(std::mem::size_of_val(array.as_slice()), 32);
             #[cfg(target_feature = "avx2")]
             unsafe {
                 result.push(Self(x86_64::_mm256_loadu_si256(
@@ -46,10 +46,10 @@ impl U31Array {
     }
 }
 
-impl Default for U31Array {
+impl Default for U31x8 {
     #[cfg(not(target_feature = "avx2"))]
     fn default() -> Self {
-        Self([0; SIMD_SIZE])
+        Self([U31::default(); SIMD_SIZE])
     }
 
     #[cfg(target_feature = "avx2")]
@@ -58,33 +58,23 @@ impl Default for U31Array {
     }
 }
 
-impl Decode for U31Array {
+impl Decode for U31x8 {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let (a, b, c, d, e, f, g, h) = Decode::decode(decoder)?;
+        let (a, b, c, d, e, f, g, h): (U31, U31, U31, U31, U31, U31, U31, U31) =
+            Decode::decode(decoder)?;
         let data = [a, b, c, d, e, f, g, h];
-        for x in data {
-            if x > i32::MAX as u32 {
-                return Err(DecodeError::UnexpectedVariant {
-                    type_name: "U31Array",
-                    allowed: &AllowedEnumVariants::Range {
-                        min: 0,
-                        max: i32::MAX as u32,
-                    },
-                    found: x,
-                });
-            }
-        }
 
+        // Safety
+        debug_assert_eq!(std::mem::size_of_val(data.as_slice()), 32);
         #[cfg(target_feature = "avx2")]
         let data = unsafe { x86_64::_mm256_loadu_si256(data.as_ptr() as *const __m256i) };
 
         Ok(Self(data))
     }
 }
+bincode::impl_borrow_decode!(U31x8);
 
-bincode::impl_borrow_decode!(U31Array);
-
-impl Encode for U31Array {
+impl Encode for U31x8 {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         #[cfg(not(target_feature = "avx2"))]
         let data = (
@@ -113,7 +103,7 @@ impl Encode for U31Array {
 pub struct ScorerBuilder {
     // Two-level trie mapping a pair of two keys into a cost, where
     // the first level stores the first key, and the second level stores the second key.
-    trie: Vec<BTreeMap<u32, i32>>,
+    trie: Vec<BTreeMap<U31, i32>>,
 }
 
 impl ScorerBuilder {
@@ -121,8 +111,8 @@ impl ScorerBuilder {
         Self { trie: vec![] }
     }
 
-    pub fn insert(&mut self, key1: u32, key2: u32, cost: i32) {
-        let key1 = usize::from_u32(key1);
+    pub fn insert(&mut self, key1: U31, key2: U31, cost: i32) {
+        let key1 = usize::from_u32(key1.get());
         if key1 >= self.trie.len() {
             self.trie.resize(key1 + 1, BTreeMap::new());
         }
@@ -130,9 +120,9 @@ impl ScorerBuilder {
     }
 
     #[inline(always)]
-    fn check_base(base: u32, second_map: &BTreeMap<u32, i32>, checks: &[u32]) -> bool {
+    fn check_base(base: u32, second_map: &BTreeMap<U31, i32>, checks: &[u32]) -> bool {
         for &key2 in second_map.keys() {
-            if let Some(check) = checks.get(usize::from_u32(base ^ key2)) {
+            if let Some(check) = checks.get(usize::from_u32(base ^ key2.get())) {
                 if *check != UNUSED_CHECK {
                     return false;
                 }
@@ -152,7 +142,7 @@ impl ScorerBuilder {
             }
             bases[key1] = base;
             for (key2, cost) in second_map {
-                let pos = base ^ key2;
+                let pos = base ^ key2.get();
                 let pos = usize::from_u32(pos);
                 if pos >= checks.len() {
                     checks.resize(pos + 1, UNUSED_CHECK);
@@ -251,12 +241,12 @@ impl Encode for Scorer {
 impl Scorer {
     #[cfg(not(target_feature = "avx2"))]
     #[inline(always)]
-    fn retrieve_cost(&self, key1: u32, key2: u32) -> Option<i32> {
-        if let Some(base) = self.bases.get(usize::from_u32(key1)) {
-            let pos = base ^ key2;
+    fn retrieve_cost(&self, key1: U31, key2: U31) -> Option<i32> {
+        if let Some(base) = self.bases.get(usize::from_u32(key1.get())) {
+            let pos = base ^ key2.get();
             let pos = usize::from_u32(pos);
             if let Some(check) = self.checks.get(pos) {
-                if *check == key1 {
+                if *check == key1.get() {
                     return Some(self.costs[pos]);
                 }
             }
@@ -266,7 +256,7 @@ impl Scorer {
 
     #[cfg(not(target_feature = "avx2"))]
     #[inline(always)]
-    pub fn accumulate_cost(&self, keys1: &[U31Array], keys2: &[U31Array]) -> i32 {
+    pub fn accumulate_cost(&self, keys1: &[U31x8], keys2: &[U31x8]) -> i32 {
         let mut score = 0;
         for (key1, key2) in keys1.iter().zip(keys2) {
             for (&key1, &key2) in key1.0.iter().zip(&key2.0) {
@@ -280,7 +270,7 @@ impl Scorer {
 
     /// # Safety
     ///
-    /// Arguments must satisfy the following constraints.
+    /// Arguments must satisfy the following constraints:
     ///
     /// * 0 <= key1
     /// * 0 <= key2
@@ -329,14 +319,14 @@ impl Scorer {
 
     /// # Safety
     ///
-    /// Arguments must satisfy the following constraints.
+    /// Arguments must satisfy the following constraints:
     ///
     /// * 0 <= key1
     /// * 0 <= key2
     /// * self.costs.len() == self.checks.len()
     #[cfg(target_feature = "avx2")]
     #[inline(always)]
-    pub fn accumulate_cost(&self, keys1: &[U31Array], keys2: &[U31Array]) -> i32 {
+    pub fn accumulate_cost(&self, keys1: &[U31x8], keys2: &[U31x8]) -> i32 {
         unsafe {
             let mut sums = x86_64::_mm256_set1_epi32(0);
             for (key1, key2) in keys1.iter().zip(keys2) {
@@ -367,97 +357,115 @@ mod tests {
     #[test]
     fn retrieve_cost_test() {
         let mut builder = ScorerBuilder::new();
-        builder.insert(18, 17, 1);
-        builder.insert(4, 9, 2);
-        builder.insert(17, 0, 3);
-        builder.insert(17, 12, 4);
-        builder.insert(8, 6, 5);
-        builder.insert(2, 5, 6);
-        builder.insert(12, 18, 7);
-        builder.insert(9, 1, 8);
-        builder.insert(19, 5, 9);
-        builder.insert(9, 4, 10);
-        builder.insert(0, 19, 11);
-        builder.insert(2, 19, 12);
-        builder.insert(7, 9, 13);
-        builder.insert(18, 9, 14);
-        builder.insert(17, 4, 15);
-        builder.insert(9, 6, 16);
-        builder.insert(13, 0, 17);
-        builder.insert(1, 4, 18);
-        builder.insert(0, 18, 19);
-        builder.insert(18, 11, 20);
+        builder.insert(U31::new(18).unwrap(), U31::new(17).unwrap(), 1);
+        builder.insert(U31::new(4).unwrap(), U31::new(9).unwrap(), 2);
+        builder.insert(U31::new(17).unwrap(), U31::new(0).unwrap(), 3);
+        builder.insert(U31::new(17).unwrap(), U31::new(12).unwrap(), 4);
+        builder.insert(U31::new(8).unwrap(), U31::new(6).unwrap(), 5);
+        builder.insert(U31::new(2).unwrap(), U31::new(5).unwrap(), 6);
+        builder.insert(U31::new(12).unwrap(), U31::new(18).unwrap(), 7);
+        builder.insert(U31::new(9).unwrap(), U31::new(1).unwrap(), 8);
+        builder.insert(U31::new(19).unwrap(), U31::new(5).unwrap(), 9);
+        builder.insert(U31::new(9).unwrap(), U31::new(4).unwrap(), 10);
+        builder.insert(U31::new(0).unwrap(), U31::new(19).unwrap(), 11);
+        builder.insert(U31::new(2).unwrap(), U31::new(19).unwrap(), 12);
+        builder.insert(U31::new(7).unwrap(), U31::new(9).unwrap(), 13);
+        builder.insert(U31::new(18).unwrap(), U31::new(9).unwrap(), 14);
+        builder.insert(U31::new(17).unwrap(), U31::new(4).unwrap(), 15);
+        builder.insert(U31::new(9).unwrap(), U31::new(6).unwrap(), 16);
+        builder.insert(U31::new(13).unwrap(), U31::new(0).unwrap(), 17);
+        builder.insert(U31::new(1).unwrap(), U31::new(4).unwrap(), 18);
+        builder.insert(U31::new(0).unwrap(), U31::new(18).unwrap(), 19);
+        builder.insert(U31::new(18).unwrap(), U31::new(11).unwrap(), 20);
         let scorer = builder.build();
 
-        assert_eq!(scorer.retrieve_cost(0, 18), Some(19));
-        assert_eq!(scorer.retrieve_cost(0, 19), Some(11));
-        assert_eq!(scorer.retrieve_cost(9, 4), Some(10));
-        assert_eq!(scorer.retrieve_cost(9, 6), Some(16));
-        assert_eq!(scorer.retrieve_cost(0, 0), None);
-        assert_eq!(scorer.retrieve_cost(9, 5), None);
+        assert_eq!(
+            scorer.retrieve_cost(U31::new(0).unwrap(), U31::new(18).unwrap()),
+            Some(19)
+        );
+        assert_eq!(
+            scorer.retrieve_cost(U31::new(0).unwrap(), U31::new(19).unwrap()),
+            Some(11)
+        );
+        assert_eq!(
+            scorer.retrieve_cost(U31::new(9).unwrap(), U31::new(4).unwrap()),
+            Some(10)
+        );
+        assert_eq!(
+            scorer.retrieve_cost(U31::new(9).unwrap(), U31::new(6).unwrap()),
+            Some(16)
+        );
+        assert_eq!(
+            scorer.retrieve_cost(U31::new(0).unwrap(), U31::new(0).unwrap()),
+            None
+        );
+        assert_eq!(
+            scorer.retrieve_cost(U31::new(9).unwrap(), U31::new(5).unwrap()),
+            None
+        );
     }
 
     #[test]
     fn accumulate_cost_test() {
         let mut builder = ScorerBuilder::new();
-        builder.insert(18, 17, 1);
-        builder.insert(4, 9, 2);
-        builder.insert(17, 0, 3);
-        builder.insert(17, 12, 4);
-        builder.insert(8, 6, 5);
-        builder.insert(2, 5, 6);
-        builder.insert(12, 18, 7);
-        builder.insert(9, 1, 8);
-        builder.insert(19, 5, 9);
-        builder.insert(9, 4, 10);
-        builder.insert(0, 19, 11);
-        builder.insert(2, 19, 12);
-        builder.insert(7, 9, 13);
-        builder.insert(18, 9, 14);
-        builder.insert(17, 4, 15);
-        builder.insert(9, 6, 16);
-        builder.insert(13, 0, 17);
-        builder.insert(1, 4, 18);
-        builder.insert(0, 18, 19);
-        builder.insert(18, 11, 20);
+        builder.insert(U31::new(18).unwrap(), U31::new(17).unwrap(), 1);
+        builder.insert(U31::new(4).unwrap(), U31::new(9).unwrap(), 2);
+        builder.insert(U31::new(17).unwrap(), U31::new(0).unwrap(), 3);
+        builder.insert(U31::new(17).unwrap(), U31::new(12).unwrap(), 4);
+        builder.insert(U31::new(8).unwrap(), U31::new(6).unwrap(), 5);
+        builder.insert(U31::new(2).unwrap(), U31::new(5).unwrap(), 6);
+        builder.insert(U31::new(12).unwrap(), U31::new(18).unwrap(), 7);
+        builder.insert(U31::new(9).unwrap(), U31::new(1).unwrap(), 8);
+        builder.insert(U31::new(19).unwrap(), U31::new(5).unwrap(), 9);
+        builder.insert(U31::new(9).unwrap(), U31::new(4).unwrap(), 10);
+        builder.insert(U31::new(0).unwrap(), U31::new(19).unwrap(), 11);
+        builder.insert(U31::new(2).unwrap(), U31::new(19).unwrap(), 12);
+        builder.insert(U31::new(7).unwrap(), U31::new(9).unwrap(), 13);
+        builder.insert(U31::new(18).unwrap(), U31::new(9).unwrap(), 14);
+        builder.insert(U31::new(17).unwrap(), U31::new(4).unwrap(), 15);
+        builder.insert(U31::new(9).unwrap(), U31::new(6).unwrap(), 16);
+        builder.insert(U31::new(13).unwrap(), U31::new(0).unwrap(), 17);
+        builder.insert(U31::new(1).unwrap(), U31::new(4).unwrap(), 18);
+        builder.insert(U31::new(0).unwrap(), U31::new(18).unwrap(), 19);
+        builder.insert(U31::new(18).unwrap(), U31::new(11).unwrap(), 20);
         let scorer = builder.build();
 
         assert_eq!(
             scorer.accumulate_cost(
-                &U31Array::to_simd_vec(&[
-                    18,
-                    17,
-                    0,
+                &U31x8::to_simd_vec(&[
+                    U31::new(18).unwrap(),
+                    U31::new(17).unwrap(),
+                    U31::new(0).unwrap(),
                     INVALID_FEATURE_ID,
-                    8,
-                    12,
-                    19,
+                    U31::new(8).unwrap(),
+                    U31::new(12).unwrap(),
+                    U31::new(19).unwrap(),
                     INVALID_FEATURE_ID,
                     INVALID_FEATURE_ID,
-                    9,
-                    0,
-                    7,
-                    17,
-                    13,
-                    0,
+                    U31::new(9).unwrap(),
+                    U31::new(0).unwrap(),
+                    U31::new(7).unwrap(),
+                    U31::new(17).unwrap(),
+                    U31::new(13).unwrap(),
+                    U31::new(0).unwrap(),
                     INVALID_FEATURE_ID
                 ]),
-                &U31Array::to_simd_vec(&[
-                    17,
-                    0,
-                    0,
+                &U31x8::to_simd_vec(&[
+                    U31::new(17).unwrap(),
+                    U31::new(0).unwrap(),
+                    U31::new(0).unwrap(),
                     INVALID_FEATURE_ID,
-                    6,
-                    18,
-                    5,
+                    U31::new(6).unwrap(),
+                    U31::new(18).unwrap(),
+                    U31::new(5).unwrap(),
                     INVALID_FEATURE_ID,
                     INVALID_FEATURE_ID,
-                    9,
-                    19,
-                    9,
-                    4,
-                    0,
-                    18,
+                    U31::new(9).unwrap(),
+                    U31::new(19).unwrap(),
+                    U31::new(9).unwrap(),
+                    U31::new(4).unwrap(),
+                    U31::new(0).unwrap(),
+                    U31::new(18).unwrap(),
                     INVALID_FEATURE_ID
                 ]),
             ),

--- a/vibrato/src/dictionary/connector/raw_connector/scorer.rs
+++ b/vibrato/src/dictionary/connector/raw_connector/scorer.rs
@@ -43,6 +43,7 @@ impl U31Array {
 }
 
 impl Default for U31Array {
+    #[cfg(not(target_feature = "avx2"))]
     fn default() -> Self {
         Self([0; SIMD_SIZE])
     }

--- a/vibrato/src/dictionary/connector/raw_connector/scorer.rs
+++ b/vibrato/src/dictionary/connector/raw_connector/scorer.rs
@@ -23,7 +23,6 @@ pub struct U31Array([u32; SIMD_SIZE]);
 pub struct U31Array(__m256i);
 
 impl U31Array {
-    #[cfg(not(target_feature = "avx2"))]
     pub fn to_simd_vec(data: &[u32]) -> Vec<Self> {
         let mut result = vec![];
         for xs in data.chunks(SIMD_SIZE) {

--- a/vibrato/src/dictionary/connector/raw_connector/scorer.rs
+++ b/vibrato/src/dictionary/connector/raw_connector/scorer.rs
@@ -33,9 +33,11 @@ impl U31Array {
             result.push(Self(array));
 
             #[cfg(target_feature = "avx2")]
-            result.push(Self(x86_64::_mm256_loadu_si256(
-                array.as_ptr() as *const __m256i
-            )));
+            unsafe {
+                result.push(Self(x86_64::_mm256_loadu_si256(
+                    array.as_ptr() as *const __m256i
+                )));
+            }
         }
         result
     }
@@ -71,7 +73,7 @@ impl Decode for U31Array {
         }
 
         #[cfg(target_feature = "avx2")]
-        let data = x86_64::_mm256_loadu_si256(data.as_ptr() as *const __m256i);
+        let data = unsafe { x86_64::_mm256_loadu_si256(data.as_ptr() as *const __m256i) };
 
         Ok(Self(data))
     }

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -51,6 +51,7 @@ compile_error!("`target_pointer_width` must be 32 or 64");
 pub mod common;
 pub mod dictionary;
 pub mod errors;
+mod num;
 mod sentence;
 pub mod token;
 pub mod tokenizer;

--- a/vibrato/src/num.rs
+++ b/vibrato/src/num.rs
@@ -38,14 +38,15 @@ const U31_VALID_RANGE: AllowedEnumVariants = AllowedEnumVariants::Range {
 impl Decode for U31 {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let x = Decode::decode(decoder)?;
-        if x > Self::MAX.get() {
-            return Err(DecodeError::UnexpectedVariant {
+        if let Some(x) = Self::new(x) {
+            Ok(x)
+        } else {
+            Err(DecodeError::UnexpectedVariant {
                 type_name: "U31",
                 allowed: &U31_VALID_RANGE,
                 found: x,
-            });
+            })
         }
-        Ok(Self(x))
     }
 }
 

--- a/vibrato/src/num.rs
+++ b/vibrato/src/num.rs
@@ -38,15 +38,11 @@ const U31_VALID_RANGE: AllowedEnumVariants = AllowedEnumVariants::Range {
 impl Decode for U31 {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let x = Decode::decode(decoder)?;
-        if let Some(x) = Self::new(x) {
-            Ok(x)
-        } else {
-            Err(DecodeError::UnexpectedVariant {
-                type_name: "U31",
-                allowed: &U31_VALID_RANGE,
-                found: x,
-            })
-        }
+        Self::new(x).ok_or(DecodeError::UnexpectedVariant {
+            type_name: "U31",
+            allowed: &U31_VALID_RANGE,
+            found: x,
+        })
     }
 }
 

--- a/vibrato/src/num.rs
+++ b/vibrato/src/num.rs
@@ -1,0 +1,56 @@
+use bincode::{
+    de::Decoder,
+    enc::Encoder,
+    error::{AllowedEnumVariants, DecodeError, EncodeError},
+    Decode, Encode,
+};
+
+#[derive(Clone, Copy, Default, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct U31(u32);
+
+impl U31 {
+    pub const MAX: Self = Self(0x7fff_ffff);
+
+    #[inline(always)]
+    pub const fn new(x: u32) -> Option<Self> {
+        if x <= Self::MAX.get() {
+            Some(Self(x))
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+const U31_VALID_RANGE: AllowedEnumVariants = AllowedEnumVariants::Range {
+    min: 0,
+    max: U31::MAX.get(),
+};
+
+impl Decode for U31 {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let x = Decode::decode(decoder)?;
+        if x > Self::MAX.get() {
+            return Err(DecodeError::UnexpectedVariant {
+                type_name: "U31",
+                allowed: &U31_VALID_RANGE,
+                found: x,
+            });
+        }
+        Ok(Self(x))
+    }
+}
+
+bincode::impl_borrow_decode!(U31);
+
+impl Encode for U31 {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.0, encoder)?;
+        Ok(())
+    }
+}

--- a/vibrato/src/num.rs
+++ b/vibrato/src/num.rs
@@ -5,6 +5,9 @@ use bincode::{
     Decode, Encode,
 };
 
+/// Represents an integer from 0 to 2^31 - 1.
+///
+/// This type guarantees that the sign bit of a 32-bit integer is always zero.
 #[derive(Clone, Copy, Default, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct U31(u32);


### PR DESCRIPTION
This PR changes to make groups of feature IDs in 256-bit units so that `vmovdqa` is more likely to be called instead of `vmovdqu`.

Benchmark results:
* main: 7.764 [sec]
* this branch: 7.035 [sec]