### PR TITLE
Remove example in vibrato/readme

### DIFF
--- a/vibrato/README.md
+++ b/vibrato/README.md
@@ -1,37 +1,10 @@
 # vibrato
 
-Vibrato is a fast implementation of tokenization (or morphological analysis) based on the viterbi algorithm.
+Vibrato is a fast implementation of tokenization (or morphological analysis) based on the Viterbi algorithm.
 
-## Examples
+## API documentation
 
-```rust
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-
-use vibrato::{Dictionary, Tokenizer};
-
-let file = File::open("src/tests/resources/system.dic").unwrap();
-let dict = Dictionary::read(BufReader::new(file)).unwrap();
-
-let tokenizer = vibrato::Tokenizer::new(dict);
-let mut worker = tokenizer.new_worker();
-
-worker.reset_sentence("京都東京都");
-worker.tokenize();
-assert_eq!(worker.num_tokens(), 2);
-
-let t0 = worker.token(0);
-assert_eq!(t0.surface(), "京都");
-assert_eq!(t0.range_char(), 0..2);
-assert_eq!(t0.range_byte(), 0..6);
-assert_eq!(t0.feature(), "京都,名詞,固有名詞,地名,一般,*,*,キョウト,京都,*,A,*,*,*,1/5");
-
-let t1 = worker.token(1);
-assert_eq!(t1.surface(), "東京都");
-assert_eq!(t1.range_char(), 2..5);
-assert_eq!(t1.range_byte(), 6..15);
-assert_eq!(t1.feature(), "東京都,名詞,固有名詞,地名,一般,*,*,トウキョウト,東京都,*,B,5/9,*,5/9,*");
-```
+https://docs.rs/vibrato
 
 ## License
 


### PR DESCRIPTION
This PR removes the Example section in vibrato/readme and adds the link to the API document instead because
- the code is not tested automatically, and 
- taking care of the example in updates increases our maintenance costs.
