### PR TITLE
Disable tests with Beta Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
           - nightly
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Beta version is not in demand