### PR TITLE
Modify CI with MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,8 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
+        # Run clippy only on stable to ignore unreasonable old warnings.
+        continue-on-error: ${{ matrix.rust != 'stable' }}
         run: cargo clippy -- -D warnings -W clippy::nursery
 
       - name: Run cargo test (no-default-features)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,63 +17,42 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.63.0 # MSRV
           - stable
           - nightly
     steps:
-      - uses: actions/checkout@v2
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+      - uses: actions/checkout@v3
+      - name: Install ${{ matrix.rust }}
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt,clippy
+          rustup default ${{ matrix.rust }}
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: clippy
-          args: -- -D warnings -W clippy::nursery
+        run: cargo clippy -- -D warnings -W clippy::nursery
 
       - name: Run cargo test (no-default-features)
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: test
-          args: --release --no-default-features
+        run: cargo test --release --no-default-features
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: test
-          args: --release --all-features
+        run: cargo test --release --all-features
 
       - name: Run cargo test with AVX2
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
         env:
           RUSTFLAGS: '-C target-feature=+avx2'
-        with:
-          command: test
-          args: --release --all-features
+        run: cargo test --release --all-features
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        with:
-          command: doc
-          args: --no-deps
+        run: cargo doc --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,8 @@
 name: build
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches: [ main ]
   pull_request:

--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vibrato"
 version = "0.3.1"
 edition = "2021"
+rust-version = "1.63"
 authors = [
     "Shunsuke Kanda <shnsk.knd@gmail.com>",
     "Koichi Akabe <vbkaisetsu@gmail.com>",


### PR DESCRIPTION
This PR modifies CI to avoid actions-rs, add scheduling, and specify MSRV.

(Clippy is evaluated only on stable to avoid unreasonable warnings such as https://github.com/daac-tools/vibrato/actions/runs/3477212601/jobs/5813150448)