### PR TITLE
Separate lifetime parameter

### DIFF
--- a/vibrato/src/token.rs
+++ b/vibrato/src/token.rs
@@ -5,14 +5,14 @@ use crate::dictionary::LexType;
 use crate::tokenizer::worker::Worker;
 
 /// Resultant token.
-pub struct Token<'a> {
-    worker: &'a Worker<'a>,
+pub struct Token<'w, 't> {
+    worker: &'w Worker<'t>,
     index: usize,
 }
 
-impl<'a> Token<'a> {
+impl<'w, 't> Token<'w, 't> {
     #[inline(always)]
-    pub(crate) const fn new(worker: &'a Worker, index: usize) -> Self {
+    pub(crate) const fn new(worker: &'w Worker<'t>, index: usize) -> Self {
         Self { worker, index }
     }
 
@@ -33,14 +33,14 @@ impl<'a> Token<'a> {
 
     /// Gets the surface string of the token.
     #[inline(always)]
-    pub fn surface(&self) -> &str {
+    pub fn surface(&self) -> &'w str {
         let sent = &self.worker.sent;
         &sent.raw()[self.range_byte()]
     }
 
     /// Gets the feature string of the token.
     #[inline(always)]
-    pub fn feature(&self) -> &str {
+    pub fn feature(&self) -> &'t str {
         let (_, node) = &self.worker.top_nodes[self.index];
         self.worker
             .tokenizer
@@ -88,7 +88,7 @@ impl<'a> Token<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for Token<'a> {
+impl<'w, 't> std::fmt::Debug for Token<'w, 't> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Token")
             .field("surface", &self.surface())
@@ -105,20 +105,20 @@ impl<'a> std::fmt::Debug for Token<'a> {
 }
 
 /// Iterator of tokens.
-pub struct TokenIter<'a> {
-    worker: &'a Worker<'a>,
+pub struct TokenIter<'w, 't> {
+    worker: &'w Worker<'t>,
     i: usize,
 }
 
-impl<'a> TokenIter<'a> {
+impl<'w, 't> TokenIter<'w, 't> {
     #[inline(always)]
-    pub(crate) const fn new(worker: &'a Worker, i: usize) -> Self {
+    pub(crate) const fn new(worker: &'w Worker<'t>, i: usize) -> Self {
         Self { worker, i }
     }
 }
 
-impl<'a> Iterator for TokenIter<'a> {
-    type Item = Token<'a>;
+impl<'w, 't> Iterator for TokenIter<'w, 't> {
+    type Item = Token<'w, 't>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {

--- a/vibrato/src/tokenizer/worker.rs
+++ b/vibrato/src/tokenizer/worker.rs
@@ -10,17 +10,17 @@ use crate::tokenizer::Tokenizer;
 ///
 /// It holds the internal data structures used in tokenization,
 /// which can be reused to avoid unnecessary memory reallocation.
-pub struct Worker<'a> {
-    pub(crate) tokenizer: &'a Tokenizer,
+pub struct Worker<'t> {
+    pub(crate) tokenizer: &'t Tokenizer,
     pub(crate) sent: Sentence,
     pub(crate) lattice: Lattice,
     pub(crate) top_nodes: Vec<(usize, Node)>,
     pub(crate) counter: Option<ConnIdCounter>,
 }
 
-impl<'a> Worker<'a> {
+impl<'t> Worker<'t> {
     /// Creates a new instance.
-    pub(crate) fn new(tokenizer: &'a Tokenizer) -> Self {
+    pub(crate) fn new(tokenizer: &'t Tokenizer) -> Self {
         Self {
             tokenizer,
             sent: Sentence::new(),
@@ -62,14 +62,14 @@ impl<'a> Worker<'a> {
 
     /// Gets the `i`-th resultant token.
     #[inline(always)]
-    pub fn token(&self, i: usize) -> Token {
+    pub fn token<'w>(&'w self, i: usize) -> Token<'w, 't> {
         let index = self.num_tokens() - i - 1;
         Token::new(self, index)
     }
 
     /// Creates an iterator of resultant tokens.
     #[inline(always)]
-    pub const fn token_iter(&'a self) -> TokenIter<'a> {
+    pub const fn token_iter<'w>(&'w self) -> TokenIter<'w, 't> {
         TokenIter::new(self, 0)
     }
 


### PR DESCRIPTION
The current implementation uses a single parameter `'a` for the `Worker` and the `Tokenizer`.

For this reason, the `Worker` cannot be changed while the feature strings are borrowed.
But actually, the `Tokenizer` owns the feature strings, and borrowing feature strings is not concerned with whether or not the `Worker` can be changed.

This branch solves this problem by giving the `Worker` and the `Tokenizer` independent lifetime parameters.