### PR TITLE
Publish members of WordIdx

### DIFF
--- a/vibrato/src/dictionary/word_idx.rs
+++ b/vibrato/src/dictionary/word_idx.rs
@@ -3,8 +3,11 @@ use crate::dictionary::LexType;
 /// Identifier of a word.
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
 pub struct WordIdx {
-    pub(crate) lex_type: LexType,
-    pub(crate) word_id: u32,
+    /// Type of a lexicon that contains this word.
+    pub lex_type: LexType,
+
+    /// ID of this word.
+    pub word_id: u32,
 }
 
 impl Default for WordIdx {


### PR DESCRIPTION
The current implementation of python-vibrato caches all Python strings into the memory.
However, if the tokenizer receives a large amount of text that generates unknown words, all of them will be cached and runs out of memory.

This branch exposes members of `WordIdx` to be able to determine if the token is registered in the dictionary.
This will ensure that unknown words are not cached.
https://github.com/daac-tools/python-vibrato/compare/cache-only-registered