### PR TITLE
Add const variable `VERSION`

### DIFF
--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -71,4 +71,4 @@ pub use dictionary::{Dictionary, SystemDictionaryBuilder};
 pub use tokenizer::Tokenizer;
 
 /// Version number of this library.
-pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/vibrato/src/lib.rs
+++ b/vibrato/src/lib.rs
@@ -69,3 +69,6 @@ mod tests;
 
 pub use dictionary::{Dictionary, SystemDictionaryBuilder};
 pub use tokenizer::Tokenizer;
+
+/// Version number of this library.
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
This branch adds a const variable `VERSION` to indicate the version number of the crate.

This is useful to indicate the version number to users of other language bindings.