### PR TITLE
Update MSRV to 1.64.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.64.0 # MSRV
           - stable
           - nightly
     steps:

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -2,6 +2,7 @@
 name = "compile"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/dictgen/Cargo.toml
+++ b/dictgen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dictgen"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }  # MIT or Apache-2.0

--- a/evaluate/Cargo.toml
+++ b/evaluate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "evaluate"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 default-run = "evaluate"
 

--- a/map/Cargo.toml
+++ b/map/Cargo.toml
@@ -2,6 +2,7 @@
 name = "map"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 default-run = "map"
 

--- a/tokenize/Cargo.toml
+++ b/tokenize/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tokenize"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/train/Cargo.toml
+++ b/train/Cargo.toml
@@ -2,6 +2,7 @@
 name = "train"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }  # MIT or Apache-2.0


### PR DESCRIPTION
This PR updates the MSRV of command line tools from 1.63.0 to 1.64.0 because `clap_lex v0.3.1` seems to require rust version 1.64.0 (see https://github.com/daac-tools/vibrato/actions/runs/3915980388/jobs/6694675709#step:4:99).

Note that this PR does not update `benchmark` because it uses an older version of clap. I'll update it in https://github.com/daac-tools/vibrato/pull/110.