### PR TITLE
Fix format strings

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -91,10 +91,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     max /= TRIALS as f64;
 
     println!("Number_of_sentences: {}", lines.len());
-    println!(
-        "Elapsed_seconds_to_tokenize_all_sentences: [{},{},{}]",
-        min, avg, max
-    );
+    println!("Elapsed_seconds_to_tokenize_all_sentences: [{min},{avg},{max}]");
 
     Ok(())
 }

--- a/map/src/reorder.rs
+++ b/map/src/reorder.rs
@@ -48,18 +48,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         output_filename.set_extension("lmap");
         let mut w = BufWriter::new(File::create(&output_filename).unwrap());
         for (i, p) in lid_probs {
-            w.write_all(format!("{}\t{}\n", i, p).as_bytes())?;
+            w.write_all(format!("{i}\t{p}\n").as_bytes())?;
         }
-        println!("Wrote {:?}", output_filename);
+        println!("Wrote {output_filename:?}");
     }
     {
         let mut output_filename = args.mapping_out;
         output_filename.set_extension("rmap");
         let mut w = BufWriter::new(File::create(&output_filename).unwrap());
         for (i, p) in rid_probs {
-            w.write_all(format!("{}\t{}\n", i, p).as_bytes())?;
+            w.write_all(format!("{i}\t{p}\n").as_bytes())?;
         }
-        println!("Wrote {:?}", output_filename);
+        println!("Wrote {output_filename:?}");
     }
 
     Ok(())

--- a/vibrato/src/dictionary/connector/dual_connector.rs
+++ b/vibrato/src/dictionary/connector/dual_connector.rs
@@ -62,10 +62,7 @@ impl DualConnector {
                     candidate_idx = trial_idx;
                 }
             }
-            eprintln!(
-                "Removed feature template: #{}, matrix size: {}",
-                candidate_idx, min_matrix_size
-            );
+            eprintln!("Removed feature template: #{candidate_idx}, matrix size: {min_matrix_size}");
             matrix_indices.remove(&candidate_idx);
         }
         matrix_indices


### PR DESCRIPTION
Clippy on Rust 1.67 reports warnings about this.