### PR TITLE
Automate Cargo Publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,9 +4,13 @@ on:
   schedule:
     - cron: '0 0 * * *'
   push:
-    branches: [ main ]
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
@@ -59,3 +63,20 @@ jobs:
       - name: Run cargo doc
         continue-on-error: ${{ matrix.rust == 'nightly' }}
         run: cargo doc --no-deps
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ build ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: Run cargo publish
+        working-directory: ${{github.workspace}}/vibrato
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
This PR automates `cargo publish` with CI like [daachorse](https://github.com/daac-tools/daachorse/blob/main/.github/workflows/rust.yml).

An API token has already been set to `CRATES_TOKEN`. No problem.