### PR TITLE
Remove unnecessary checking for input length

### DIFF
--- a/vibrato/src/dictionary/lexicon/map/trie.rs
+++ b/vibrato/src/dictionary/lexicon/map/trie.rs
@@ -50,7 +50,6 @@ impl Trie {
         &'a self,
         input: &'a [char],
     ) -> impl Iterator<Item = TrieMatch> + 'a {
-        debug_assert!(input.len() <= 0xFFFF);
         self.da
             .common_prefix_search(input.iter().cloned())
             .map(move |(value, end_char)| TrieMatch::new(value, end_char))


### PR DESCRIPTION
Fixes #127 

The limitation of the input length is removed in #72, but the previous change left `debug_assert!()` by mistake.