### PR TITLE
Add snippet for reading distributed dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ $ echo '本とカレーの街神保町へようこそ。' | cargo run --release 
 本 と カレー の 街 神保 町 へ ようこそ 。
 ```
 
+### Notes for Vibrato APIs
+
+The distributed models are compressed in zstd format.
+If you want to load these compressed models with the `vibrato` API,
+you must decompress them outside of the API.
+
+```rust
+let reader = zstd::Decoder::new(File::open("path/to/system.dic.zst")?)?;
+let dict = Dictionary::read(reader)?;
+```
+
 ## Tokenization options
 
 ### MeCab-compatible options

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If you want to load these compressed models with the `vibrato` API,
 you must decompress them outside of the API.
 
 ```rust
-# Requires zstd crate or ruzstd crate
+// Requires zstd crate or ruzstd crate
 let reader = zstd::Decoder::new(File::open("path/to/system.dic.zst")?)?;
 let dict = Dictionary::read(reader)?;
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you want to load these compressed models with the `vibrato` API,
 you must decompress them outside of the API.
 
 ```rust
+# Requires zstd crate or ruzstd crate
 let reader = zstd::Decoder::new(File::open("path/to/system.dic.zst")?)?;
 let dict = Dictionary::read(reader)?;
 ```


### PR DESCRIPTION
This PR adds a snippet to read distributed models through APIs.

I wondered if I should also add to the document of `Dictionary::read()` that:

```
When you load a distribution model, check its specifications.
```

However, users will visit the top page's README when using distributed models. Therefore, I have only added a snippet to the README.