### PR TITLE
Update bincode version to 2.0.0-rc.3

### DIFF
--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing"]
 
 [dependencies]
-bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "derive"] }  # MIT
+bincode = { version = "2.0.0-rc.3", default-features = false, features = ["std", "alloc", "derive"] }  # MIT
 crawdad = "0.3.0" # MIT or Apache-2.0
 csv-core = "0.1.10" # Unlicense or MIT
 hashbrown = "0.12" # MIT or Apache-2.0

--- a/vibrato/Cargo.toml
+++ b/vibrato/Cargo.toml
@@ -17,8 +17,7 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing"]
 
 [dependencies]
-bincode = "=2.0.0-rc.2" # MIT
-bincode_derive = "=2.0.0-rc.2" # MIT
+bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "derive"] }  # MIT
 crawdad = "0.3.0" # MIT or Apache-2.0
 csv-core = "0.1.10" # Unlicense or MIT
 hashbrown = "0.12" # MIT or Apache-2.0

--- a/vibrato/src/common.rs
+++ b/vibrato/src/common.rs
@@ -6,7 +6,6 @@ pub const fn bincode_config() -> config::Configuration<LittleEndian, Fixint> {
     config::standard()
         .with_little_endian()
         .with_fixed_int_encoding()
-        .write_fixed_array_length()
 }
 
 /// The maximam length of an input sentence.


### PR DESCRIPTION
This PR updates the bincode version from 2.0.0-rc.2 to 2.0.0-rc.3. With [this change](https://github.com/bincode-org/bincode/pull/625), `write_fixed_array_length` was removed.

~~After merging this PR, I'll update the vibrato version to 0.6.0 and distribute new models (although since Vibrato did not include long fixed-length arrays (more 32 elements) by chance, it seems that older models can be loaded even if the bincode version is increased).~~

I investigated the source codes and confirmed no part writes fixed arrays with bincode. Also, I checked that all distributed models can be loaded with 2.0.0-rc.3. Therefore, I'll update the vibrato version to 0.5.1 and keep the models.